### PR TITLE
Fix `run_tests` response

### DIFF
--- a/Editor/Tools/RunTestsTool.cs
+++ b/Editor/Tools/RunTestsTool.cs
@@ -114,6 +114,12 @@ namespace McpUnity.Tools
         // Called when a test finishes
         public void TestFinished(ITestResultAdaptor result)
         {
+            // Skip test suites (tests with children)
+            if (result.Test.HasChildren)
+            {
+                return;
+            }
+            
             _testResults.Add(new TestResult
             {
                 Name = result.Test.Name,

--- a/Editor/Tools/RunTestsTool.cs
+++ b/Editor/Tools/RunTestsTool.cs
@@ -166,7 +166,10 @@ namespace McpUnity.Tools
                 {
                     ["success"] = true,
                     ["type"] = "text",
-                    ["message"] = summary["message"].Value<string>()
+                    ["message"] = summary["message"].Value<string>(),
+                    ["testCount"] = summary["testCount"],
+                    ["passCount"] = summary["passCount"],
+                    ["results"] = summary["results"]
                 });
             }
             catch (Exception ex)

--- a/Editor/Tools/RunTestsTool.cs
+++ b/Editor/Tools/RunTestsTool.cs
@@ -136,8 +136,11 @@ namespace McpUnity.Tools
             // Create test results summary
             var summary = new JObject
             {
-                ["testCount"] = _testResults.Count,
-                ["passCount"] = _testResults.FindAll(r => r.Passed).Count,
+                ["testCount"] = result.PassCount + result.FailCount + result.SkipCount + result.InconclusiveCount,
+                ["passCount"] = result.PassCount,
+                ["failCount"] = result.FailCount,
+                ["skipCount"] = result.SkipCount,
+                ["inconclusiveCount"] = result.InconclusiveCount,
                 ["duration"] = result.Duration,
                 ["success"] = result.ResultState == "Passed",
                 ["status"] = "completed",
@@ -169,6 +172,9 @@ namespace McpUnity.Tools
                     ["message"] = summary["message"].Value<string>(),
                     ["testCount"] = summary["testCount"],
                     ["passCount"] = summary["passCount"],
+                    ["failCount"] = summary["failCount"],
+                    ["skipCount"] = summary["skipCount"],
+                    ["inconclusiveCount"] = summary["inconclusiveCount"],
                     ["results"] = summary["results"]
                 });
             }

--- a/Server/build/tools/runTestsTool.js
+++ b/Server/build/tools/runTestsTool.js
@@ -57,6 +57,9 @@ async function toolHandler(mcpUnity, params) {
     const testResults = response.results || [];
     const testCount = response.testCount || 0;
     const passCount = response.passCount || 0;
+    const failCount = response.failCount || 0;
+    const inconclusiveCount = response.inconclusiveCount || 0;
+    const skipCount = response.skipCount || 0;
     // Format the result message
     let resultMessage = `${passCount}/${testCount} tests passed`;
     if (testCount > 0 && passCount < testCount) {
@@ -69,14 +72,16 @@ async function toolHandler(mcpUnity, params) {
         content: [
             {
                 type: 'text',
-                text: response.message || resultMessage
+                text: resultMessage || response.message
             },
             {
                 type: 'text',
                 text: JSON.stringify({
                     testCount,
                     passCount,
-                    failCount: testCount - passCount,
+                    failCount,
+                    inconclusiveCount,
+                    skipCount,
                     results: testResults
                 }, null, 2)
             }

--- a/Server/src/tools/runTestsTool.ts
+++ b/Server/src/tools/runTestsTool.ts
@@ -75,6 +75,9 @@ async function toolHandler(mcpUnity: McpUnity, params: any): Promise<CallToolRes
   const testResults = response.results || [];
   const testCount = response.testCount || 0;
   const passCount = response.passCount || 0;
+  const failCount = response.failCount || 0;
+  const inconclusiveCount = response.inconclusiveCount || 0;
+  const skipCount = response.skipCount || 0;
   
   // Format the result message
   let resultMessage = `${passCount}/${testCount} tests passed`;
@@ -89,14 +92,16 @@ async function toolHandler(mcpUnity: McpUnity, params: any): Promise<CallToolRes
     content: [
       {
         type: 'text',
-        text: response.message || resultMessage
+        text: resultMessage || response.message
       },
       {
         type: 'text',
         text: JSON.stringify({
           testCount,
           passCount,
-          failCount: testCount - passCount,
+          failCount,
+          inconclusiveCount,
+          skipCount,
           results: testResults
         }, null, 2)
       }


### PR DESCRIPTION
### Problem

Test count in response is always 0.
No test results.

e.g.,
```
Test run completed: UnityModelContextProtocolSandbox - Failed(Child)

{
  "testCount": 0,
  "passCount": 0,
  "failCount": 0,
  "results": []
}
```

### Fixes

Returns
- Test total, pass, fail, inconclusive, and skip count.
- Test results

e.g.,
```
2/3 tests passed. Failed tests: FailTestDemo

{
  "testCount": 3,
  "passCount": 2,
  "failCount": 1,
  "inconclusiveCount": 0,
  "skipCount": 0,
  "results": [
    {
      "name": "FailTestDemo",
      "fullName": "McpServerDemo.Tests.McpServerTest.FailTestDemo",
      "result": "Failed",
      "message": "This is a demo failure.",
      "duration": 0.0338517
    },
    {
      "name": "SuccessTest1",
      "fullName": "McpServerDemo.Tests.McpServerTest.SuccessTest1",
      "result": "Passed",
      "message": null,
      "duration": 0.63412
    },
    {
      "name": "SuccessTest2",
      "fullName": "McpServerDemo.Tests.McpServerTest.SuccessTest2",
      "result": "Passed",
      "message": null,
      "duration": 0.5749152
    }
  ]
}
```

### Discussions

When there are a lot of tests, you shouldn't return the results of all the tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Test results now display detailed counts for failed, skipped, and inconclusive tests, in addition to passed tests.
  - The full list of individual test results is included in the output for enhanced visibility.
- **Improvements**
  - Test summary reporting is more accurate and detailed, providing clearer feedback after running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->