### PR TITLE
Add timeout settings for the WebSocket and the test execution.

### DIFF
--- a/Editor/Services/ITestRunnerService.cs
+++ b/Editor/Services/ITestRunnerService.cs
@@ -26,12 +26,10 @@ namespace McpUnity.Services
         /// <param name="testMode">Test mode to run</param>
         /// <param name="testFilter">Optional test filter</param>
         /// <param name="completionSource">TaskCompletionSource to resolve when tests are complete</param>
-        /// <param name="timeoutMinutes">Timeout in minutes, defaults to 10</param>
         /// <returns>Task that resolves with test results when tests are complete</returns>
         void ExecuteTests(
             TestMode testMode,
             string testFilter,
-            TaskCompletionSource<JObject> completionSource,
-            int timeoutMinutes = 1);
+            TaskCompletionSource<JObject> completionSource);
     }
 }

--- a/Editor/Services/TestRunnerService.cs
+++ b/Editor/Services/TestRunnerService.cs
@@ -49,13 +49,11 @@ namespace McpUnity.Services
         /// <param name="testMode">Test mode to run</param>
         /// <param name="testFilter">Optional test filter</param>
         /// <param name="completionSource">TaskCompletionSource to resolve when tests are complete</param>
-        /// <param name="timeoutMinutes">Timeout in minutes, defaults to 10</param>
         /// <returns>Task that resolves with test results when tests are complete</returns>
         public async void ExecuteTests(
             TestMode testMode, 
             string testFilter, 
-            TaskCompletionSource<JObject> completionSource, 
-            int timeoutMinutes = 1)
+            TaskCompletionSource<JObject> completionSource)
         {
             // Create filter
             var filter = new Filter
@@ -72,15 +70,18 @@ namespace McpUnity.Services
             // Execute tests
             _testRunnerApi.Execute(new ExecutionSettings(filter));
 
+            // Use timeout from settings if not specified
+            var timeoutSeconds =  McpUnitySettings.Instance.TestTimeoutSeconds;
+            
             Task completedTask = await Task.WhenAny(
                 completionSource.Task,
-                Task.Delay(TimeSpan.FromMinutes(timeoutMinutes))
+                Task.Delay(TimeSpan.FromSeconds(timeoutSeconds))
             );
 
             if (completedTask != completionSource.Task)
             {
                 completionSource.SetResult(McpUnitySocketHandler.CreateErrorResponse(
-                    $"Test run timed out after {timeoutMinutes} minutes",
+                    $"Test run timed out after {timeoutSeconds} seconds",
                     "test_runner_timeout"
                 ));
             }

--- a/Editor/UnityBridge/McpUnityEditorWindow.cs
+++ b/Editor/UnityBridge/McpUnityEditorWindow.cs
@@ -107,6 +107,24 @@ namespace McpUnity.Unity
             
             EditorGUILayout.Space();
             
+            // Test timeout setting
+            EditorGUILayout.BeginHorizontal();
+            int newTimeout = EditorGUILayout.IntField(new GUIContent("Test Timeout (seconds)", "Timeout in seconds for test execution"), settings.TestTimeoutSeconds);
+            if (newTimeout < 60)
+            {
+                newTimeout = 60;
+                Debug.LogError("Test timeout must be at least 60 seconds.");
+            }
+            
+            if (newTimeout != settings.TestTimeoutSeconds)
+            {
+                settings.TestTimeoutSeconds = newTimeout;
+                settings.SaveSettings();
+            }
+            EditorGUILayout.EndHorizontal();
+            
+            EditorGUILayout.Space();
+            
             // Auto start server toggle
             bool autoStartServer = EditorGUILayout.Toggle(new GUIContent("Auto Start Server", "Automatically starts the MCP server when Unity opens"), settings.AutoStartServer);
             if (autoStartServer != settings.AutoStartServer)

--- a/Editor/UnityBridge/McpUnitySettings.cs
+++ b/Editor/UnityBridge/McpUnitySettings.cs
@@ -3,6 +3,7 @@ using System.IO;
 using McpUnity.Utils;
 using UnityEngine;
 using UnityEditor;
+using UnityEngine.Serialization;
 
 namespace McpUnity.Unity
 {
@@ -27,6 +28,9 @@ namespace McpUnity.Unity
         
         [Tooltip("Whether to show info logs in the Unity console")]
         public bool EnableInfoLogs = true;
+        
+        [Tooltip("Timeout in seconds for test execution")]
+        public int TestTimeoutSeconds = 60;
 
         /// <summary>
         /// Singleton instance of settings

--- a/README-ja.md
+++ b/README-ja.md
@@ -211,6 +211,38 @@ MCP Unityサーバーを起動するには2つの方法があります：
    node Server/build/index.js
    ```
 
+## オプション: タイムアウト設定
+
+### WebSocketタイムアウト
+
+デフォルトでは、MCPサーバーとWebSocket間のタイムアウトは 10 秒です。
+MCP構成ファイルで、次のように環境変数 `UNITY_REQUEST_TIMEOUT` として指定できます。
+
+```json
+{
+  "mcpServers": {
+    "mcp-unity": {
+      "command": "node",
+      "args": [
+        "ABSOLUTE/PATH/TO/mcp-unity/Server/build/index.js"
+      ],
+      "env": {
+        "UNITY_PORT": "8090",
+        "UNITY_REQUEST_TIMEOUT": "300"
+      }
+    }
+  }
+}
+```
+
+> [!TIP]  
+> AIコーディングIDE（Claude Desktop、Cursor IDE、Windsurf IDE など）とMCPサーバー間のタイムアウトは、AIコーディングIDEによって異なります。
+
+### テスト実行タイムアウト
+
+デフォルトでは、Unityエディター側の `run_tests` ツールの実行タイムアウトは 60 秒です。
+**Tools > MCP Unity > Server Window** の **Test Timeout (seconds)** で指定できます。
+
 ## <a name="debug-server"></a>サーバーのデバッグ
 
 MCP Unityサーバーをデバッグするには、以下の方法を使用できます：

--- a/README.md
+++ b/README.md
@@ -236,6 +236,38 @@ By default, the WebSocket server runs on port 8090. You can change this port in 
 
 </details>
 
+## Optional: Set Timeout
+
+### WebSocket Timeout
+
+By default, the timeout between the MCP server and the WebSocket is 10 seconds.
+You can specify it as an environment variable `UNITY_REQUEST_TIMEOUT` in your MCP configuration file as follows:
+
+```json
+{
+  "mcpServers": {
+    "mcp-unity": {
+      "command": "node",
+      "args": [
+        "ABSOLUTE/PATH/TO/mcp-unity/Server/build/index.js"
+      ],
+      "env": {
+        "UNITY_PORT": "8090",
+        "UNITY_REQUEST_TIMEOUT": "300"
+      }
+    }
+  }
+}
+```
+
+> [!TIP]  
+> The timeout between your AI Coding IDE (e.g., Claude Desktop, Cursor IDE, Windsurf IDE) and the MCP Server depends on the AI coding IDE.
+
+### Test Execution Timeout
+
+By default, the execution timeout for the `run_tests` tool in the Unity editor is 60 seconds.
+You can specify it in **Test Timeout (seconds)** in the **Tools > MCP Unity > Server Window**.
+
 ## <a name="debug-server"></a>Debugging the Server
 
 <details>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -213,6 +213,38 @@ MCP Unity 通过将 Unity `Library/PackedCache` 文件夹添加到您的工作�
    node Server/build/index.js
    ```
 
+## 可选：设置超时
+
+### WebSocket 超时
+
+默认情况下，MCP 服务器与 WebSocket 之间的超时时间为 10 秒。
+您可以在 MCP 配置文件中将其指定为环境变量 `UNITY_REQUEST_TIMEOUT`，如下所示：
+
+```json
+{
+  "mcpServers": {
+    "mcp-unity": {
+      "command": "node",
+      "args": [
+        "ABSOLUTE/PATH/TO/mcp-unity/Server/build/index.js"
+      ],
+      "env": {
+        "UNITY_PORT": "8090",
+        "UNITY_REQUEST_TIMEOUT": "300"
+      }
+    }
+  }
+}
+```
+
+> [!TIP]  
+> 您的 AI 编码 IDE（例如，Claude Desktop、Cursor IDE、Windsurf IDE）和 MCP 服务器之间的超时取决于 AI 编码 IDE。
+
+### 测试执行超时
+
+默认情况下，Unity 编辑器中 `run_tests` 工具的执行超时时间为 60 秒。
+您可以在 **Tools > MCP Unity > Server Window** 中的 **Test Timeout (seconds)** 中指定它。
+
 ## <a name="debug-server"></a>调试服务器
 
 要调试 MCP Unity 服务器，您可以使用以下方法：

--- a/Server/build/unity/mcpUnity.js
+++ b/Server/build/unity/mcpUnity.js
@@ -8,7 +8,7 @@ export class McpUnity {
     port;
     ws = null;
     pendingRequests = new Map();
-    REQUEST_TIMEOUT = 10000;
+    REQUEST_TIMEOUT;
     retryDelay = 1000;
     constructor(logger) {
         this.logger = logger;
@@ -19,6 +19,10 @@ export class McpUnity {
         const envPort = process.env.UNITY_PORT || envRegistry;
         this.port = envPort ? parseInt(envPort, 10) : 8090;
         this.logger.info(`Using port: ${this.port} for Unity WebSocket connection`);
+        // Initialize timeout from environment variable (in seconds; it is the same as Cline) or use default (10 seconds)
+        const envTimeout = process.env.UNITY_REQUEST_TIMEOUT;
+        this.REQUEST_TIMEOUT = envTimeout ? parseInt(envTimeout, 10) * 1000 : 10000;
+        this.logger.info(`Using request timeout: ${this.REQUEST_TIMEOUT / 1000} seconds`);
     }
     /**
      * Start the Unity connection

--- a/Server/src/unity/mcpUnity.ts
+++ b/Server/src/unity/mcpUnity.ts
@@ -33,7 +33,7 @@ export class McpUnity {
   private port: number;
   private ws: WebSocket | null = null;
   private pendingRequests: Map<string, PendingRequest> = new Map<string, PendingRequest>();
-  private readonly REQUEST_TIMEOUT = 10000;
+  private readonly REQUEST_TIMEOUT: number;
   private retryDelay = 1000;
   
   constructor(logger: Logger) {
@@ -46,8 +46,12 @@ export class McpUnity {
     
     const envPort = process.env.UNITY_PORT || envRegistry;
     this.port = envPort ? parseInt(envPort, 10) : 8090;
-    
     this.logger.info(`Using port: ${this.port} for Unity WebSocket connection`);
+    
+    // Initialize timeout from environment variable (in seconds; it is the same as Cline) or use default (10 seconds)
+    const envTimeout = process.env.UNITY_REQUEST_TIMEOUT;
+    this.REQUEST_TIMEOUT = envTimeout ? parseInt(envTimeout, 10) * 1000 : 10000;
+    this.logger.info(`Using request timeout: ${this.REQUEST_TIMEOUT / 1000} seconds`);
   }
   
   /**


### PR DESCRIPTION
### Changes

#### Add WebSocket timeout setting

Can specify it as an environment variable `UNITY_REQUEST_TIMEOUT` in the MCP configuration file as follows:

```json
{
  "mcpServers": {
    "mcp-unity": {
      "command": "node",
      "args": [
        "ABSOLUTE/PATH/TO/mcp-unity/Server/build/index.js"
      ],
      "env": {
        "UNITY_PORT": "8090",
        "UNITY_REQUEST_TIMEOUT": "300"
      }
    }
  }
}
```

#### Add test execution timeout setting

Can specify it in **Test Timeout (seconds)** in the **Tools > MCP Unity > Server Window**.
<img width="305" alt="timeout" src="https://github.com/user-attachments/assets/954a62b8-cbed-47c3-8ea9-5a456b511d72" />

