### PR TITLE
Add returnsOnlyFailures option into `run_tests` tool

### DIFF
--- a/Server/src/tools/runTestsTool.ts
+++ b/Server/src/tools/runTestsTool.ts
@@ -10,7 +10,8 @@ const toolName = 'run_tests';
 const toolDescription = 'Runs Unity\'s Test Runner tests';
 const paramsSchema = z.object({
   testMode: z.string().optional().describe('The test mode to run (EditMode or PlayMode) - defaults to EditMode (optional)'),
-  testFilter: z.string().optional().describe('The specific test filter to run (e.g. specific test name or namespace) (optional)')
+  testFilter: z.string().optional().describe('The specific test filter to run (e.g. specific test name or namespace) (optional)'),
+  returnsOnlyFailures: z.boolean().optional().default(true).describe('Whether to show only failed tests in the results (optional)')
 });
 
 /**
@@ -52,14 +53,15 @@ export function createRunTestsTool(server: McpServer, mcpUnity: McpUnity, logger
  * @throws McpUnityError if the request to Unity fails
  */
 async function toolHandler(mcpUnity: McpUnity, params: any): Promise<CallToolResult> {
-  const { testMode = 'EditMode', testFilter } = params;
+  const { testMode = 'EditMode', testFilter, returnsOnlyFailures = true } = params;
 
   // Create and wait for the test run
   const response = await mcpUnity.sendRequest({
     method: toolName,
     params: { 
       testMode,
-      testFilter
+      testFilter,
+      returnsOnlyFailures
     }
   });
   
@@ -84,6 +86,7 @@ async function toolHandler(mcpUnity: McpUnity, params: any): Promise<CallToolRes
   if (testCount > 0 && passCount < testCount) {
     resultMessage += `. Failed tests: ${testResults
       .filter((r: any) => r.result !== 'Passed')
+      .filter((r: any) => !r.result.startsWith('Skipped'))
       .map((r: any) => r.name)
       .join(', ')}`;
   }


### PR DESCRIPTION
## Overview
This PR adds a new `returnsOnlyFailures` parameter to the `run_tests` tool, allowing users to filter test results to show only non-passing tests.

## Changes
- Added `returnsOnlyFailures` parameter (boolean, default: true) to the run_tests tool schema in TypeScript
- Implemented the parameter handling in the tool handler to pass it to Unity
- Added a private field in the RunTestsTool.cs class to store the parameter value
- Modified the RunFinished method to filter test results based on the parameter value

## Implementation Details
When `returnsOnlyFailures` is set to true (default), only non-passing tests (Failed, Error, Inconclusive) are included in the results. When set to false, all test results are included.

## Examples

#### Request `run_tests`
```json
{
  "testMode": "PlayMode",
  "returnsOnlyFailures": true
}
```

#### Response
```json
1/8 tests passed. Failed tests: ErrorDemo, FailedDemo, InconclusiveDemo

{
  "testCount": 8,
  "passCount": 1,
  "failCount": 2,
  "inconclusiveCount": 1,
  "skipCount": 4,
  "results": [
    {
      "name": "ErrorDemo",
      "fullName": "McpServerDemo.TestResultsTest.ErrorDemo",
      "result": "Failed:Error",
      "message": "System.ApplicationException : Exception sample",
      "duration": 0.0122885
    },
    {
      "name": "FailedDemo",
      "fullName": "McpServerDemo.TestResultsTest.FailedDemo",
      "result": "Failed",
      "message": "  Assert failure sample\n  Expected: False\n  But was:  True\n",
      "duration": 0.0048901
    },
    {
      "name": "InconclusiveDemo",
      "fullName": "McpServerDemo.TestResultsTest.InconclusiveDemo",
      "result": "Inconclusive",
      "message": "  Inconclusive sample\n  Expected: False\n  But was:  True\n",
      "duration": 0.000668
    }
  ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an option to display only failed (and inconclusive) test results, excluding passed and skipped tests by default.
- **Improvements**
	- Enhanced test result filtering to provide clearer and more focused output on failures.
- **Configuration**
	- Introduced a configurable parameter to control whether only failures are returned in test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->