### PR TITLE
Fix server auto-restart logic on domain reloading

### DIFF
--- a/Editor/UnityBridge/McpUnityServer.cs
+++ b/Editor/UnityBridge/McpUnityServer.cs
@@ -38,13 +38,10 @@ namespace McpUnity.Unity
             EditorApplication.quitting += Instance.StopServer;
 
             // Auto-restart server after domain reload
-            EditorApplication.delayCall += () =>
+            if (McpUnitySettings.Instance.AutoStartServer)
             {
-                if (McpUnitySettings.Instance.AutoStartServer)
-                {
-                    Instance.StartServer();
-                }
-            };
+                Instance.StartServer();
+            }
         }
         
         /// <summary>


### PR DESCRIPTION
### Probrem

The WebSocket server is not restarted after domain reloading (e.g., compiled).

Conditions:
The Unity editor does not have focus.

### Fixes

Removed unnecessary use of `EditorApplication.delayCall`.

`delayCall` is

> Delegate which is called once after all inspectors update.

If the Unity Editor does not have focus, the Inspector will not be updated, and `delayCall` will not be executed.

refs https://docs.unity3d.com/ScriptReference/EditorApplication-delayCall.html

refs #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the server auto-start logic for more immediate and streamlined startup behavior in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->