### PR TITLE
fix: Map 'info' log type to Unity's 'Log' type for console log retrieval

### DIFF
--- a/Editor/Services/ConsoleLogsService.cs
+++ b/Editor/Services/ConsoleLogsService.cs
@@ -12,6 +12,12 @@ namespace McpUnity.Services
     /// </summary>
     public class ConsoleLogsService : IConsoleLogsService
     {
+        // Static mapping for MCP log types to Unity log types
+        private static readonly Dictionary<string, string> LogTypeMapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "info", "Log" }
+        };
+        
         // Structure to store log information
         private class LogEntry
         {
@@ -76,15 +82,13 @@ namespace McpUnity.Services
             JArray logsArray = new JArray();
             bool filter = !string.IsNullOrEmpty(logType);
             
+            // Map MCP log types to Unity log types outside the loop for better performance
+            string unityLogType = filter && LogTypeMapping.TryGetValue(logType, out string mapped) ? mapped : logType;
+            
             lock (_logEntries)
             {
                 foreach (var entry in _logEntries)
                 {
-                    // Map MCP log types to Unity log types
-                    string unityLogType = logType;
-                    if (logType.Equals("info", System.StringComparison.OrdinalIgnoreCase))
-                        unityLogType = "Log";
-                    
                     if (filter && !entry.Type.ToString().Equals(unityLogType, System.StringComparison.OrdinalIgnoreCase))
                         continue;
                     logsArray.Add(new JObject

--- a/Editor/Services/ConsoleLogsService.cs
+++ b/Editor/Services/ConsoleLogsService.cs
@@ -80,7 +80,12 @@ namespace McpUnity.Services
             {
                 foreach (var entry in _logEntries)
                 {
-                    if (filter && !entry.Type.ToString().Equals(logType, System.StringComparison.OrdinalIgnoreCase))
+                    // Map MCP log types to Unity log types
+                    string unityLogType = logType;
+                    if (logType.Equals("info", System.StringComparison.OrdinalIgnoreCase))
+                        unityLogType = "Log";
+                    
+                    if (filter && !entry.Type.ToString().Equals(unityLogType, System.StringComparison.OrdinalIgnoreCase))
                         continue;
                     logsArray.Add(new JObject
                     {


### PR DESCRIPTION
## Summary
• Fix info log type mapping issue in ConsoleLogsService where MCP's "info" parameter didn't match Unity's "Log" type
• Add mapping logic to convert "info" to "Log" before filtering log entries in GetAllLogsAsJson method

## Environment Details
- **Unity Version**: Unity 6 (6000.0.26f1) - tested and confirmed
- **Platform**: macOS 15.5 (Sequoia)
- **MCP Unity Version**: v1.1.0+
- **Affected Tool**: `get_console_logs` with `logType: "info"` parameter

## Problem Description
The `get_console_logs` MCP tool was unable to retrieve info-level logs when using the `"info"` logType parameter. This occurred because:

1. **Unity Internal Logging**: `Debug.Log()` messages are stored as `LogType.Log` (string: `"Log"`)
2. **MCP Parameter**: Client requests use `logType: "info"`
3. **Filtering Logic**: Direct string comparison `"info" \!= "Log"` caused info logs to be filtered out

### Reproduction Steps
```typescript
// This would return empty array before the fix
get_console_logs({ logType: "info" })
```

## Root Cause
In `ConsoleLogsService.cs` line 83, the filtering logic:
```csharp
if (filter && \!entry.Type.ToString().Equals(logType, System.StringComparison.OrdinalIgnoreCase))
```
Would compare `"info"` (MCP parameter) with `"Log"` (Unity's LogType.Log.ToString()), causing a mismatch.

## Solution
Added type mapping logic before filtering:
```csharp
// Map MCP log types to Unity log types
string unityLogType = logType;
if (logType.Equals("info", System.StringComparison.OrdinalIgnoreCase))
    unityLogType = "Log";
```

## Test Plan
- [x] Send info log via `send_console_log` tool with `type: "info"`
- [x] Retrieve info logs via `get_console_logs` tool with `logType: "info"`
- [x] Verify warning and error logs still work correctly
- [x] Test in Unity 6 (6000.0.26f1) on macOS 15.5 (Sequoia)
- [x] Confirm no regression in existing functionality

## Impact
This fix enables proper info log retrieval through MCP tools, making debugging and monitoring more effective for MCP Unity users.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log filtering by correctly mapping external log types to internal types, ensuring more accurate display of log entries when filtering by log type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->