### PR TITLE
fix: prevent exceptions from manual test

### DIFF
--- a/Editor/Services/TestRunnerService.cs
+++ b/Editor/Services/TestRunnerService.cs
@@ -180,6 +180,7 @@ namespace McpUnity.Services
             
             var summary = BuildResultJson(_results, result);
             _tcs?.TrySetResult(summary);
+            _tcs = null;
         }
 
         #endregion

--- a/Editor/Services/TestRunnerService.cs
+++ b/Editor/Services/TestRunnerService.cs
@@ -145,6 +145,9 @@ namespace McpUnity.Services
         /// </summary>
         public void RunStarted(ITestAdaptor testsToRun)
         {
+            if (_tcs == null)
+                return;
+            
             McpLogger.LogInfo($"Test run started: {testsToRun?.Name}");
         }
 
@@ -161,6 +164,9 @@ namespace McpUnity.Services
         /// </summary>
         public void TestFinished(ITestResultAdaptor result)
         {
+            if (_tcs == null)
+                return;
+            
             _results.Add(result);
         }
 
@@ -169,6 +175,9 @@ namespace McpUnity.Services
         /// </summary>
         public void RunFinished(ITestResultAdaptor result)
         {
+            if (_tcs == null)
+                return;
+            
             var summary = BuildResultJson(_results, result);
             _tcs?.TrySetResult(summary);
         }


### PR DESCRIPTION
### Description
This PR fixes an issue where exceptions could occur during manual test execution. The fix adds null checks for the `_tcs` (Task Completion Source) field in three key methods of the `TestRunnerService` class:

1. `RunStarted` - Checks if `_tcs` is null before proceeding
2. `TestFinished` - Adds null check before adding results
3. `RunFinished` - Ensures `_tcs` is not null before building and setting the result

These changes prevent potential `NullReferenceException`s that could occur when test callbacks are triggered but no task is waiting for the results, which can happen during manual test execution.

### Changes that Break Backward Compatibility
N/A

### Documentation
N/A

*Created with [Palmier](https://www.palmier.io)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability by preventing errors during test execution callbacks when certain internal states are uninitialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->