### PR TITLE
feat: add remote host configuration support for Unity WebSocket connection

### DIFF
--- a/Server~/src/unity/mcpUnity.ts
+++ b/Server~/src/unity/mcpUnity.ts
@@ -34,6 +34,7 @@ interface UnityResponse {
 export class McpUnity {
   private logger: Logger;
   private port: number | null = null;
+  private host: string = 'localhost';
   private ws: WebSocket | null = null;
   private pendingRequests: Map<string, PendingRequest> = new Map<string, PendingRequest>();
   private requestTimeout = 10000;
@@ -80,6 +81,10 @@ export class McpUnity {
     this.port = configPort ? parseInt(configPort, 10) : 8090;
     this.logger.info(`Using port: ${this.port} for Unity WebSocket connection`);
     
+    // Check environment variable first, then config file, then default to localhost
+    const configHost = process.env.UNITY_HOST || config.Host;
+    this.host = configHost || 'localhost';
+    
     // Initialize timeout from environment variable (in seconds; it is the same as Cline) or use default (10 seconds)
     const configTimeout = config.RequestTimeoutSeconds;
     this.requestTimeout = configTimeout ? parseInt(configTimeout, 10) * 1000 : 10000;
@@ -100,7 +105,7 @@ export class McpUnity {
     this.disconnect();
     
     return new Promise<void>((resolve, reject) => {
-      const wsUrl = `ws://localhost:${this.port}/McpUnity`;
+      const wsUrl = `ws://${this.host}:${this.port}/McpUnity`;
       this.logger.debug(`Connecting to ${wsUrl}...`);
       
       // Create connection options with headers for client identification


### PR DESCRIPTION
## Summary

Enables remote Unity Editor connections across network. Useful for development setups where Unity runs on different machine.

## Changes

- Add configurable host property to McpUnity class
- Support `UNITY_HOST` environment variable as first priority
- Support `Host` configuration in Unity's McpUnitySettings.json as fallback  
- Update WebSocket URL to use configurable host instead of hardcoded localhost
- Maintains backward compatibility

## Usage Example

**Remote Unity setup:**
```bash
# Unity running on 192.168.1.100, launch MCP bridge on different machine
UNITY_HOST=192.168.1.100 node server.js
```

**Or via Unity settings file:**
```json
{
  "Host": "192.168.1.100",
  "Port": 8090
}
```

**Default behavior (unchanged):**
```bash
# Still connects to localhost:8090 if no host specified
node server.js
```
## Testing

Tested with Unity Editor on Windows PC and MCP bridge on remote Ubuntu server. Verified GameObject creation, selection, etc work remotely.