### PR TITLE
GetGameObjectResource: Add a tool call, and some workarounds

### DIFF
--- a/Editor/Tools/GetGameObjectTool.cs
+++ b/Editor/Tools/GetGameObjectTool.cs
@@ -1,0 +1,87 @@
+using McpUnity.Resources;
+using McpUnity.Unity;
+using UnityEngine;
+using UnityEditor;
+using Newtonsoft.Json.Linq;
+
+namespace McpUnity.Tools
+{
+    /// <summary>
+    /// Tool for retrieving detailed information about a specific GameObject.
+    /// This tool provides the same functionality as the get_gameobject resource,
+    /// but as a tool that can be invoked directly without URI template parameters.
+    /// </summary>
+    public class GetGameObjectTool : McpToolBase
+    {
+        public GetGameObjectTool()
+        {
+            Name = "get_gameobject";
+            Description = "Retrieves detailed information about a specific GameObject by instance ID, name, or hierarchical path (e.g., \"Parent/Child/MyObject\"). Returns all component properties including Transform position, rotation, scale, and more.";
+        }
+
+        /// <summary>
+        /// Execute the GetGameObject tool with the provided parameters
+        /// </summary>
+        /// <param name="parameters">Tool parameters as a JObject. Should include 'idOrName' which can be an instance ID, name, or path</param>
+        /// <returns>A JObject containing the GameObject data</returns>
+        public override JObject Execute(JObject parameters)
+        {
+            // Validate parameters
+            if (parameters == null || !parameters.ContainsKey("idOrName"))
+            {
+                return McpUnitySocketHandler.CreateErrorResponse(
+                    "Missing required parameter: idOrName",
+                    "validation_error"
+                );
+            }
+
+            string idOrName = parameters["idOrName"]?.ToObject<string>();
+
+            if (string.IsNullOrEmpty(idOrName))
+            {
+                return McpUnitySocketHandler.CreateErrorResponse(
+                    "Parameter 'idOrName' cannot be null or empty",
+                    "validation_error"
+                );
+            }
+
+            GameObject gameObject = null;
+
+            // Try to parse as an instance ID first
+            if (int.TryParse(idOrName, out int instanceId))
+            {
+                // Unity Instance IDs are typically negative, but we'll accept any integer
+                UnityEngine.Object unityObject = EditorUtility.InstanceIDToObject(instanceId);
+                gameObject = unityObject as GameObject;
+            }
+            else
+            {
+                // Otherwise, treat it as a name or hierarchical path
+                gameObject = GameObject.Find(idOrName);
+            }
+
+            // Check if the GameObject was found
+            if (gameObject == null)
+            {
+                return McpUnitySocketHandler.CreateErrorResponse(
+                    $"GameObject with '{idOrName}' reference not found. Make sure the GameObject exists and is loaded in the current scene(s).",
+                    "not_found_error"
+                );
+            }
+
+            // Convert the GameObject to a JObject using the resource's static method
+            JObject gameObjectData = GetGameObjectResource.GameObjectToJObject(gameObject, true);
+
+            // Create the response
+            return new JObject
+            {
+                ["success"] = true,
+                ["message"] = $"Retrieved GameObject data for '{gameObject.name}'",
+                ["gameObject"] = gameObjectData,
+                ["instanceId"] = gameObject.GetInstanceID()
+            };
+        }
+    }
+}
+
+

--- a/Editor/Tools/GetGameObjectTool.cs.meta
+++ b/Editor/Tools/GetGameObjectTool.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 405fbb4324c64fb0942faed640b82da2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+

--- a/Editor/UnityBridge/McpUnityServer.cs
+++ b/Editor/UnityBridge/McpUnityServer.cs
@@ -267,6 +267,10 @@ namespace McpUnity.Unity
             // Register RecompileScriptsTool
             RecompileScriptsTool recompileScriptsTool = new RecompileScriptsTool();
             _tools.Add(recompileScriptsTool.Name, recompileScriptsTool);
+            
+            // Register GetGameObjectTool
+            GetGameObjectTool getGameObjectTool = new GetGameObjectTool();
+            _tools.Add(getGameObjectTool.Name, getGameObjectTool);
         }
         
         /// <summary>

--- a/Server~/src/index.ts
+++ b/Server~/src/index.ts
@@ -17,6 +17,7 @@ import { registerCreatePrefabTool } from './tools/createPrefabTool.js';
 import { registerDeleteSceneTool } from './tools/deleteSceneTool.js';
 import { registerLoadSceneTool } from './tools/loadSceneTool.js';
 import { registerRecompileScriptsTool } from './tools/recompileScriptsTool.js';
+import { registerGetGameObjectTool } from './tools/getGameObjectTool.js';
 import { registerGetMenuItemsResource } from './resources/getMenuItemResource.js';
 import { registerGetConsoleLogsResource } from './resources/getConsoleLogsResource.js';
 import { registerGetHierarchyResource } from './resources/getScenesHierarchyResource.js';
@@ -65,6 +66,7 @@ registerCreateSceneTool(server, mcpUnity, toolLogger);
 registerDeleteSceneTool(server, mcpUnity, toolLogger);
 registerLoadSceneTool(server, mcpUnity, toolLogger);
 registerRecompileScriptsTool(server, mcpUnity, toolLogger);
+registerGetGameObjectTool(server, mcpUnity, toolLogger);
 
 // Register all resources into the MCP server
 registerGetTestsResource(server, mcpUnity, resourceLogger);

--- a/Server~/src/tools/getGameObjectTool.ts
+++ b/Server~/src/tools/getGameObjectTool.ts
@@ -1,0 +1,93 @@
+import * as z from "zod";
+import { Logger } from "../utils/logger.js";
+import { McpUnity } from "../unity/mcpUnity.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpUnityError, ErrorType } from "../utils/errors.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+// Constants for the tool
+const toolName = "get_gameobject";
+const toolDescription =
+  "Retrieves detailed information about a specific GameObject by instance ID, name, or hierarchical path (e.g., 'Parent/Child/MyObject'). Returns all component properties including Transform position, rotation, scale, and more.";
+const paramsSchema = z.object({
+  idOrName: z
+    .string()
+    .describe(
+      "The instance ID (integer), name, or hierarchical path of the GameObject to retrieve. Use hierarchical paths like 'Canvas/Panel/Button' for nested objects."
+    ),
+});
+
+/**
+ * Creates and registers the Get GameObject tool with the MCP server
+ * This tool allows retrieving detailed information about GameObjects in Unity scenes
+ *
+ * @param server The MCP server instance to register with
+ * @param mcpUnity The McpUnity instance to communicate with Unity
+ * @param logger The logger instance for diagnostic information
+ */
+export function registerGetGameObjectTool(
+  server: McpServer,
+  mcpUnity: McpUnity,
+  logger: Logger
+) {
+  logger.info(`Registering tool: ${toolName}`);
+
+  // Register this tool with the MCP server
+  server.tool(
+    toolName,
+    toolDescription,
+    paramsSchema.shape,
+    async (params: z.infer<typeof paramsSchema>) => {
+      try {
+        logger.info(`Executing tool: ${toolName}`, params);
+        const result = await toolHandler(mcpUnity, params);
+        logger.info(`Tool execution successful: ${toolName}`);
+        return result;
+      } catch (error) {
+        logger.error(`Tool execution failed: ${toolName}`, error);
+        throw error;
+      }
+    }
+  );
+}
+
+/**
+ * Handles requests for GameObject information from Unity
+ *
+ * @param mcpUnity The McpUnity instance to communicate with Unity
+ * @param params The parameters for the tool
+ * @returns A promise that resolves to the tool execution result
+ * @throws McpUnityError if the request to Unity fails
+ */
+async function toolHandler(
+  mcpUnity: McpUnity,
+  params: z.infer<typeof paramsSchema>
+): Promise<CallToolResult> {
+  const { idOrName } = params;
+
+  // Send request to Unity
+  const response = await mcpUnity.sendRequest({
+    method: toolName,
+    params: {
+      idOrName: idOrName,
+    },
+  });
+
+  if (!response.success) {
+    throw new McpUnityError(
+      ErrorType.TOOL_EXECUTION,
+      response.message || "Failed to fetch GameObject from Unity"
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(response, null, 2),
+      },
+    ],
+  };
+}
+
+


### PR DESCRIPTION
1. Cursor barfs on URIs with parameters, which means attempting to use `get_gameobject` as a resource in Cursor fails. Instead, we need a tool, which can be invoked with URI template parameters.
2. We probably need a better architecture for this long-term, but attempting to access any `gameObject` that relies on certain native C++ libraries (A* Pathfinding, FMOD) will hard crash Unity. This change looks ugly but *does* make `get_gameobject` work for codebases using these common Unity dependencies.
3. In addition `get_gameobject` will stack overflow Unity for _any_ self-referential serialization chain, which is also surprisingly common. So this adds depth limits to `SerializeValue`.

In my testing this took `get_gameobject` from "only works on the simplest objects" to "can handle everything I throw at it," but, every repo is different: ymmv.