### PR TITLE
Imporve failed tests filtering

### DIFF
--- a/Editor/Services/TestRunnerService.cs
+++ b/Editor/Services/TestRunnerService.cs
@@ -197,7 +197,7 @@ namespace McpUnity.Services
         {
             var arr = new JArray(results
                 .Where(r => !r.HasChildren)
-                .Where(r => !_returnOnlyFailures || r.ResultState == "Failed")
+                .Where(r => !_returnOnlyFailures || r.ResultState.StartsWith("Failed"))
                 .Select(r => new JObject {
                     ["name"]      = r.Name,
                     ["fullName"]  = r.FullName,


### PR DESCRIPTION
Previously, if a test failed due to an exception, the `TestRunnerService` didn't treat it as a failure: when `returnOnlyFailures` was `true`, the result was filtered out from the results array. 

This is because Test Framework [has 4 failure states](https://docs.unity3d.com/Packages/com.unity.test-framework@1.3/api/UnityEditor.TestTools.TestRunner.Api.ITestResultAdaptor.ResultState.html): `Failed`, `Failed:Error`, `Failed:Cancelled`, `Failed:Invalid`. All of them are counted as failures by the Test Runner. 

I've adjusted the state filter to include all of them in the output.