### PR TITLE
feat: Add command queuing for disconnection resilience

### DIFF
--- a/Server~/src/__tests__/commandQueue.test.ts
+++ b/Server~/src/__tests__/commandQueue.test.ts
@@ -1,0 +1,412 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { CommandQueue, CommandQueueConfig, QueuedCommand } from '../unity/commandQueue';
+import { Logger, LogLevel } from '../utils/logger';
+import { McpUnityError, ErrorType } from '../utils/errors';
+
+// Create a silent logger for tests
+const createTestLogger = (): Logger => {
+  return new Logger('Test', LogLevel.ERROR);
+};
+
+describe('CommandQueue', () => {
+  let queue: CommandQueue;
+  let logger: Logger;
+
+  beforeEach(() => {
+    logger = createTestLogger();
+    queue = new CommandQueue(logger);
+  });
+
+  afterEach(() => {
+    queue.dispose();
+  });
+
+  describe('constructor', () => {
+    it('should create with default configuration', () => {
+      const stats = queue.getStats();
+      expect(stats.maxSize).toBe(100);
+      expect(stats.size).toBe(0);
+    });
+
+    it('should accept custom configuration', () => {
+      const customQueue = new CommandQueue(logger, {
+        maxSize: 50,
+        defaultTimeout: 30000,
+        cleanupInterval: 1000,
+      });
+
+      const stats = customQueue.getStats();
+      expect(stats.maxSize).toBe(50);
+
+      customQueue.dispose();
+    });
+  });
+
+  describe('enqueue', () => {
+    it('should successfully enqueue a command', () => {
+      const result = queue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: jest.fn(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.position).toBe(1);
+      expect(queue.size).toBe(1);
+    });
+
+    it('should enqueue multiple commands in order', () => {
+      for (let i = 1; i <= 3; i++) {
+        const result = queue.enqueue({
+          id: `test-${i}`,
+          request: { method: 'test', params: {} },
+          resolve: jest.fn(),
+          reject: jest.fn(),
+        });
+        expect(result.position).toBe(i);
+      }
+
+      expect(queue.size).toBe(3);
+    });
+
+    it('should reject commands when queue is full', () => {
+      const smallQueue = new CommandQueue(logger, { maxSize: 2 });
+      const rejectFn = jest.fn();
+
+      // Fill the queue
+      smallQueue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: jest.fn(),
+      });
+      smallQueue.enqueue({
+        id: 'test-2',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: jest.fn(),
+      });
+
+      // Try to add one more
+      const result = smallQueue.enqueue({
+        id: 'test-3',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: rejectFn,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('Queue is full');
+      expect(rejectFn).toHaveBeenCalled();
+      expect(smallQueue.getStats().droppedCount).toBe(1);
+
+      smallQueue.dispose();
+    });
+  });
+
+  describe('size and isEmpty', () => {
+    it('should report correct size', () => {
+      expect(queue.size).toBe(0);
+      expect(queue.isEmpty).toBe(true);
+
+      queue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: jest.fn(),
+      });
+
+      expect(queue.size).toBe(1);
+      expect(queue.isEmpty).toBe(false);
+    });
+
+    it('should report isFull correctly', () => {
+      const smallQueue = new CommandQueue(logger, { maxSize: 1 });
+
+      expect(smallQueue.isFull).toBe(false);
+
+      smallQueue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: jest.fn(),
+      });
+
+      expect(smallQueue.isFull).toBe(true);
+
+      smallQueue.dispose();
+    });
+  });
+
+  describe('drain', () => {
+    it('should return all queued commands and clear the queue', () => {
+      const resolve1 = jest.fn();
+      const resolve2 = jest.fn();
+
+      queue.enqueue({
+        id: 'test-1',
+        request: { method: 'method1', params: {} },
+        resolve: resolve1,
+        reject: jest.fn(),
+      });
+      queue.enqueue({
+        id: 'test-2',
+        request: { method: 'method2', params: {} },
+        resolve: resolve2,
+        reject: jest.fn(),
+      });
+
+      expect(queue.size).toBe(2);
+
+      const commands = queue.drain();
+
+      expect(commands.length).toBe(2);
+      expect(commands[0].id).toBe('test-1');
+      expect(commands[1].id).toBe('test-2');
+      expect(queue.size).toBe(0);
+      expect(queue.isEmpty).toBe(true);
+    });
+
+    it('should return empty array when queue is empty', () => {
+      const commands = queue.drain();
+      expect(commands).toEqual([]);
+    });
+  });
+
+  describe('peek', () => {
+    it('should return the first command without removing it', () => {
+      queue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: jest.fn(),
+      });
+
+      const peeked = queue.peek();
+
+      expect(peeked).toBeDefined();
+      expect(peeked?.id).toBe('test-1');
+      expect(queue.size).toBe(1); // Still in queue
+    });
+
+    it('should return undefined for empty queue', () => {
+      const peeked = queue.peek();
+      expect(peeked).toBeUndefined();
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear all commands and reject them', () => {
+      const reject1 = jest.fn();
+      const reject2 = jest.fn();
+
+      queue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: reject1,
+      });
+      queue.enqueue({
+        id: 'test-2',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: reject2,
+      });
+
+      queue.clear('Test clear');
+
+      expect(queue.size).toBe(0);
+      expect(reject1).toHaveBeenCalled();
+      expect(reject2).toHaveBeenCalled();
+
+      // Check that rejection includes correct error type
+      const error1 = reject1.mock.calls[0][0] as McpUnityError;
+      expect(error1.type).toBe(ErrorType.CONNECTION);
+      expect(error1.message).toBe('Test clear');
+    });
+
+    it('should handle clearing empty queue', () => {
+      expect(() => queue.clear()).not.toThrow();
+    });
+  });
+
+  describe('cleanupExpired', () => {
+    it('should remove expired commands', async () => {
+      const shortTimeoutQueue = new CommandQueue(logger, {
+        defaultTimeout: 50, // 50ms timeout
+        cleanupInterval: 100000, // Long interval so we control cleanup
+      });
+
+      const rejectFn = jest.fn();
+
+      shortTimeoutQueue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: rejectFn,
+      });
+
+      expect(shortTimeoutQueue.size).toBe(1);
+
+      // Wait for expiration
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const expiredCount = shortTimeoutQueue.cleanupExpired();
+
+      expect(expiredCount).toBe(1);
+      expect(shortTimeoutQueue.size).toBe(0);
+      expect(rejectFn).toHaveBeenCalled();
+
+      const error = rejectFn.mock.calls[0][0] as McpUnityError;
+      expect(error.type).toBe(ErrorType.TIMEOUT);
+      expect(shortTimeoutQueue.getStats().expiredCount).toBe(1);
+
+      shortTimeoutQueue.dispose();
+    });
+
+    it('should not remove non-expired commands', () => {
+      queue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: jest.fn(),
+      });
+
+      const expiredCount = queue.cleanupExpired();
+
+      expect(expiredCount).toBe(0);
+      expect(queue.size).toBe(1);
+    });
+
+    it('should respect per-command timeout', async () => {
+      const rejectFn = jest.fn();
+
+      // Default timeout is 60s, but we set a short custom timeout
+      queue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: rejectFn,
+        timeout: 50, // 50ms timeout
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const expiredCount = queue.cleanupExpired();
+
+      expect(expiredCount).toBe(1);
+      expect(rejectFn).toHaveBeenCalled();
+    });
+  });
+
+  describe('statistics', () => {
+    it('should track statistics correctly', () => {
+      // Initial stats
+      let stats = queue.getStats();
+      expect(stats.size).toBe(0);
+      expect(stats.droppedCount).toBe(0);
+      expect(stats.expiredCount).toBe(0);
+      expect(stats.replayedCount).toBe(0);
+
+      // Add a command
+      queue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: jest.fn(),
+      });
+
+      stats = queue.getStats();
+      expect(stats.size).toBe(1);
+
+      // Record replay success
+      queue.recordReplaySuccess();
+      stats = queue.getStats();
+      expect(stats.replayedCount).toBe(1);
+    });
+
+    it('should reset statistics', () => {
+      queue.recordReplaySuccess();
+      queue.recordReplaySuccess();
+
+      let stats = queue.getStats();
+      expect(stats.replayedCount).toBe(2);
+
+      queue.resetStats();
+
+      stats = queue.getStats();
+      expect(stats.droppedCount).toBe(0);
+      expect(stats.expiredCount).toBe(0);
+      expect(stats.replayedCount).toBe(0);
+    });
+  });
+
+  describe('updateConfig', () => {
+    it('should update configuration dynamically', () => {
+      queue.updateConfig({ maxSize: 50 });
+
+      const stats = queue.getStats();
+      expect(stats.maxSize).toBe(50);
+    });
+  });
+
+  describe('dispose', () => {
+    it('should clean up resources and reject pending commands', () => {
+      const rejectFn = jest.fn();
+
+      queue.enqueue({
+        id: 'test-1',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: rejectFn,
+      });
+
+      queue.dispose();
+
+      expect(queue.size).toBe(0);
+      expect(rejectFn).toHaveBeenCalled();
+    });
+  });
+
+  describe('drain filters expired commands', () => {
+    it('should filter out expired commands when draining', async () => {
+      const shortTimeoutQueue = new CommandQueue(logger, {
+        defaultTimeout: 50,
+        cleanupInterval: 100000,
+      });
+
+      const rejectFn = jest.fn();
+      const resolveFn = jest.fn();
+
+      // Add an expired command
+      shortTimeoutQueue.enqueue({
+        id: 'expired',
+        request: { method: 'test', params: {} },
+        resolve: jest.fn(),
+        reject: rejectFn,
+        timeout: 10,
+      });
+
+      // Add a non-expired command
+      shortTimeoutQueue.enqueue({
+        id: 'valid',
+        request: { method: 'test', params: {} },
+        resolve: resolveFn,
+        reject: jest.fn(),
+        timeout: 60000,
+      });
+
+      // Wait for first command to expire
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const commands = shortTimeoutQueue.drain();
+
+      expect(commands.length).toBe(1);
+      expect(commands[0].id).toBe('valid');
+      expect(rejectFn).toHaveBeenCalled();
+
+      shortTimeoutQueue.dispose();
+    });
+  });
+});

--- a/Server~/src/unity/commandQueue.ts
+++ b/Server~/src/unity/commandQueue.ts
@@ -1,0 +1,321 @@
+import { Logger } from '../utils/logger.js';
+import { McpUnityError, ErrorType } from '../utils/errors.js';
+
+/**
+ * Represents a queued command with its metadata
+ */
+export interface QueuedCommand {
+  /** Unique identifier for the command */
+  id: string;
+  /** The request to send to Unity */
+  request: {
+    id?: string;
+    method: string;
+    params: any;
+  };
+  /** Resolve callback for the promise */
+  resolve: (value: any) => void;
+  /** Reject callback for the promise */
+  reject: (reason: any) => void;
+  /** Timestamp when the command was queued */
+  queuedAt: number;
+  /** Optional custom timeout for this specific command (in ms) */
+  timeout?: number;
+}
+
+/**
+ * Configuration options for the CommandQueue
+ */
+export interface CommandQueueConfig {
+  /** Maximum number of commands to queue (default: 100) */
+  maxSize?: number;
+  /** Default timeout in milliseconds for queued commands (default: 60000) */
+  defaultTimeout?: number;
+  /** Interval in milliseconds to check for expired commands (default: 5000) */
+  cleanupInterval?: number;
+}
+
+/**
+ * Statistics about the command queue
+ */
+export interface CommandQueueStats {
+  /** Current number of queued commands */
+  size: number;
+  /** Maximum queue size */
+  maxSize: number;
+  /** Number of commands that were dropped due to queue overflow */
+  droppedCount: number;
+  /** Number of commands that expired while queued */
+  expiredCount: number;
+  /** Number of commands successfully replayed */
+  replayedCount: number;
+}
+
+/**
+ * Result of attempting to enqueue a command
+ */
+export interface EnqueueResult {
+  /** Whether the command was successfully queued */
+  success: boolean;
+  /** Position in queue (1-indexed) if successful */
+  position?: number;
+  /** Reason for failure if not successful */
+  reason?: string;
+}
+
+/**
+ * Default configuration values
+ */
+const DEFAULT_CONFIG = {
+  maxSize: 100,
+  defaultTimeout: 60000, // 60 seconds
+  cleanupInterval: 5000  // 5 seconds
+};
+
+/**
+ * CommandQueue manages commands that are queued when the Unity connection is unavailable.
+ * Commands are stored and replayed when the connection is restored.
+ */
+export class CommandQueue {
+  private queue: QueuedCommand[] = [];
+  private config: Required<CommandQueueConfig>;
+  private cleanupTimer: NodeJS.Timeout | null = null;
+  private logger: Logger;
+
+  // Statistics
+  private droppedCount: number = 0;
+  private expiredCount: number = 0;
+  private replayedCount: number = 0;
+
+  constructor(logger: Logger, config: CommandQueueConfig = {}) {
+    this.logger = logger;
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config
+    };
+
+    // Start cleanup timer
+    this.startCleanupTimer();
+  }
+
+  /**
+   * Enqueue a command to be sent when the connection is restored
+   * @param command The command to queue (without queuedAt, which will be added automatically)
+   * @returns Result indicating whether the command was queued successfully
+   */
+  public enqueue(command: Omit<QueuedCommand, 'queuedAt'>): EnqueueResult {
+    // Check if queue is full
+    if (this.queue.length >= this.config.maxSize) {
+      this.droppedCount++;
+      this.logger.warn(`Command queue full (${this.config.maxSize}), dropping command: ${command.request.method}`);
+
+      // Reject the command immediately
+      command.reject(new McpUnityError(
+        ErrorType.CONNECTION,
+        `Command queue full (${this.config.maxSize} commands). Try again later.`
+      ));
+
+      return {
+        success: false,
+        reason: `Queue is full (max: ${this.config.maxSize})`
+      };
+    }
+
+    const queuedCommand: QueuedCommand = {
+      ...command,
+      queuedAt: Date.now(),
+      timeout: command.timeout ?? this.config.defaultTimeout
+    };
+
+    this.queue.push(queuedCommand);
+    const position = this.queue.length;
+
+    this.logger.debug(`Queued command ${command.id} (${command.request.method}), position: ${position}/${this.config.maxSize}`);
+
+    return {
+      success: true,
+      position
+    };
+  }
+
+  /**
+   * Get the number of commands currently in the queue
+   */
+  public get size(): number {
+    return this.queue.length;
+  }
+
+  /**
+   * Check if the queue is empty
+   */
+  public get isEmpty(): boolean {
+    return this.queue.length === 0;
+  }
+
+  /**
+   * Check if the queue is full
+   */
+  public get isFull(): boolean {
+    return this.queue.length >= this.config.maxSize;
+  }
+
+  /**
+   * Get all queued commands and clear the queue.
+   * Used when connection is restored to replay commands.
+   * Expired commands are filtered out and rejected before returning.
+   * @returns Array of valid (non-expired) queued commands
+   */
+  public drain(): QueuedCommand[] {
+    // Clean up expired commands first
+    this.cleanupExpired();
+
+    const commands = [...this.queue];
+    this.queue = [];
+
+    if (commands.length > 0) {
+      this.logger.info(`Draining ${commands.length} commands from queue for replay`);
+    }
+
+    return commands;
+  }
+
+  /**
+   * Peek at the next command without removing it
+   * @returns The next command in the queue, or undefined if empty
+   */
+  public peek(): QueuedCommand | undefined {
+    return this.queue[0];
+  }
+
+  /**
+   * Clear all queued commands, rejecting each with an error
+   * @param reason The reason for clearing the queue
+   */
+  public clear(reason: string = 'Queue cleared'): void {
+    const count = this.queue.length;
+
+    for (const command of this.queue) {
+      command.reject(new McpUnityError(
+        ErrorType.CONNECTION,
+        reason
+      ));
+    }
+
+    this.queue = [];
+
+    if (count > 0) {
+      this.logger.info(`Cleared ${count} commands from queue: ${reason}`);
+    }
+  }
+
+  /**
+   * Remove expired commands from the queue
+   * @returns Number of commands that were expired and removed
+   */
+  public cleanupExpired(): number {
+    const now = Date.now();
+    const initialSize = this.queue.length;
+
+    this.queue = this.queue.filter(command => {
+      const timeout = command.timeout ?? this.config.defaultTimeout;
+      const isExpired = (now - command.queuedAt) > timeout;
+
+      if (isExpired) {
+        this.expiredCount++;
+        this.logger.debug(`Command ${command.id} (${command.request.method}) expired after ${timeout}ms`);
+
+        command.reject(new McpUnityError(
+          ErrorType.TIMEOUT,
+          `Command expired after ${timeout}ms in queue`
+        ));
+
+        return false;
+      }
+
+      return true;
+    });
+
+    const expiredCount = initialSize - this.queue.length;
+    if (expiredCount > 0) {
+      this.logger.info(`Cleaned up ${expiredCount} expired commands from queue`);
+    }
+
+    return expiredCount;
+  }
+
+  /**
+   * Start the periodic cleanup timer
+   */
+  private startCleanupTimer(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+    }
+
+    this.cleanupTimer = setInterval(() => {
+      this.cleanupExpired();
+    }, this.config.cleanupInterval);
+
+    // Don't prevent process exit
+    this.cleanupTimer.unref();
+  }
+
+  /**
+   * Stop the cleanup timer
+   */
+  public stopCleanupTimer(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+
+  /**
+   * Record that a command was successfully replayed
+   */
+  public recordReplaySuccess(): void {
+    this.replayedCount++;
+  }
+
+  /**
+   * Get statistics about the command queue
+   */
+  public getStats(): CommandQueueStats {
+    return {
+      size: this.queue.length,
+      maxSize: this.config.maxSize,
+      droppedCount: this.droppedCount,
+      expiredCount: this.expiredCount,
+      replayedCount: this.replayedCount
+    };
+  }
+
+  /**
+   * Reset statistics counters
+   */
+  public resetStats(): void {
+    this.droppedCount = 0;
+    this.expiredCount = 0;
+    this.replayedCount = 0;
+  }
+
+  /**
+   * Update configuration dynamically
+   * Note: maxSize changes won't affect already-queued commands
+   */
+  public updateConfig(config: Partial<CommandQueueConfig>): void {
+    this.config = { ...this.config, ...config };
+
+    // Restart cleanup timer if interval changed
+    if (config.cleanupInterval !== undefined) {
+      this.startCleanupTimer();
+    }
+  }
+
+  /**
+   * Clean up resources
+   */
+  public dispose(): void {
+    this.stopCleanupTimer();
+    this.clear('Command queue disposed');
+  }
+}


### PR DESCRIPTION
## Summary
- Add CommandQueue class with configurable size (100 commands) and timeout (60s) for storing commands when Unity is disconnected
- Integrate queue with McpUnity for automatic queuing during reconnection states
- Add per-request `queueIfDisconnected` option in SendRequestOptions for opt-in queuing behavior
- Auto-cleanup expired commands with periodic timer and replay queued commands on connection restore

## Changes
- `Server~/src/unity/commandQueue.ts` - New CommandQueue class implementation
- `Server~/src/unity/mcpUnity.ts` - Integration with connection state management
- `Server~/src/__tests__/commandQueue.test.ts` - 21 Jest tests for comprehensive coverage

## Test plan
- [x] All 21 Jest tests pass for CommandQueue functionality
- [x] Tests cover: enqueue/drain, queue limits, timeout handling, statistics, cleanup
- [ ] Manual testing with Unity disconnection/reconnection scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)