### PR TITLE
fix: Enable private field access in UpdateComponentTool

### DIFF
--- a/Editor/Tests/UpdateComponentToolTests.cs
+++ b/Editor/Tests/UpdateComponentToolTests.cs
@@ -1,0 +1,148 @@
+using System;
+using McpUnity.Tools;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace McpUnity.Tests
+{
+    public class UpdateComponentToolTests
+    {
+        private const string TestAssetDir = "Assets/UpdateComponentToolTests";
+        private const string TestAssetPath = TestAssetDir + "/ReferencedAsset.asset";
+
+        private GameObject _gameObject;
+        private ScriptableObject _referencedAsset;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _gameObject = new GameObject("UpdateComponentToolTestObject");
+
+            if (!AssetDatabase.IsValidFolder(TestAssetDir))
+            {
+                AssetDatabase.CreateFolder("Assets", "UpdateComponentToolTests");
+            }
+
+            _referencedAsset = ScriptableObject.CreateInstance<ScriptableObject>();
+            AssetDatabase.CreateAsset(_referencedAsset, TestAssetPath);
+            AssetDatabase.SaveAssets();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_gameObject != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_gameObject);
+            }
+
+            if (AssetDatabase.IsValidFolder(TestAssetDir))
+            {
+                AssetDatabase.DeleteAsset(TestAssetDir);
+            }
+
+            AssetDatabase.Refresh();
+        }
+
+        [Test]
+        public void Execute_WithPrivateSerializedFieldInBaseClass_UpdatesValue()
+        {
+            var component = _gameObject.AddComponent<DerivedUpdateComponentToolTestComponent>();
+            var tool = new UpdateComponentTool();
+
+            JObject result = tool.Execute(new JObject
+            {
+                ["instanceId"] = _gameObject.GetInstanceID(),
+                ["componentName"] = nameof(DerivedUpdateComponentToolTestComponent),
+                ["componentData"] = new JObject
+                {
+                    ["_baseValue"] = 42
+                }
+            });
+
+            Assert.IsTrue(result["success"]?.Value<bool>() ?? false, result.ToString());
+            Assert.AreEqual(42, component.BaseValue);
+        }
+
+        [Test]
+        public void Execute_WithNestedObjectReferencePath_UpdatesReference()
+        {
+            var component = _gameObject.AddComponent<UpdateComponentToolTestComponent>();
+            var tool = new UpdateComponentTool();
+
+            JObject result = tool.Execute(new JObject
+            {
+                ["instanceId"] = _gameObject.GetInstanceID(),
+                ["componentName"] = nameof(UpdateComponentToolTestComponent),
+                ["componentData"] = new JObject
+                {
+                    ["_eventReference._event"] = TestAssetPath
+                }
+            });
+
+            Assert.IsTrue(result["success"]?.Value<bool>() ?? false, result.ToString());
+            Assert.AreSame(_referencedAsset, component.EventReference);
+        }
+
+        [Test]
+        public void Execute_WithMissingObjectReferencePath_ReturnsUpdateError()
+        {
+            var component = _gameObject.AddComponent<UpdateComponentToolTestComponent>();
+            component.SetEventReference(_referencedAsset);
+            var tool = new UpdateComponentTool();
+
+            JObject result = tool.Execute(new JObject
+            {
+                ["instanceId"] = _gameObject.GetInstanceID(),
+                ["componentName"] = nameof(UpdateComponentToolTestComponent),
+                ["componentData"] = new JObject
+                {
+                    ["_eventReference._event"] = "Assets/UpdateComponentToolTests/Missing.asset"
+                }
+            });
+
+            Assert.IsNotNull(result["error"], result.ToString());
+            StringAssert.Contains("Could not find asset", result["error"]["message"]?.ToString());
+            Assert.AreSame(_referencedAsset, component.EventReference);
+        }
+
+    }
+
+    [Serializable]
+    public class NestedEventReference
+    {
+        [SerializeField] private ScriptableObject _event;
+
+        public ScriptableObject Event => _event;
+
+        public void SetEvent(ScriptableObject value)
+        {
+            _event = value;
+        }
+    }
+
+    public class UpdateComponentToolTestComponent : MonoBehaviour
+    {
+        [SerializeField] private NestedEventReference _eventReference = new NestedEventReference();
+
+        public ScriptableObject EventReference => _eventReference.Event;
+
+        public void SetEventReference(ScriptableObject value)
+        {
+            _eventReference.SetEvent(value);
+        }
+    }
+
+    public class BaseUpdateComponentToolTestComponent : MonoBehaviour
+    {
+        [SerializeField] private int _baseValue;
+
+        public int BaseValue => _baseValue;
+    }
+
+    public class DerivedUpdateComponentToolTestComponent : BaseUpdateComponentToolTestComponent
+    {
+    }
+}

--- a/Editor/Tests/UpdateComponentToolTests.cs.meta
+++ b/Editor/Tests/UpdateComponentToolTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f7d6d963fd14294a8e91f27a14851b2

--- a/Editor/Tools/UpdateComponentTool.cs
+++ b/Editor/Tools/UpdateComponentTool.cs
@@ -238,13 +238,54 @@ namespace McpUnity.Tools
             
             return null;
         }
+
+        /// <summary>
+        /// Recursively search for a field through the type hierarchy
+        /// </summary>
+        /// <param name="type">The type to start searching from</param>
+        /// <param name="fieldName">The name of the field to find</param>
+        /// <returns>The FieldInfo if found, null otherwise</returns>
+        private FieldInfo GetFieldRecursive(Type type, string fieldName)
+        {
+            while (type != null && type != typeof(object))
+            {
+                FieldInfo field = type.GetField(fieldName, 
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                if (field != null) 
+                    return field;
+                type = type.BaseType;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Recursively search for a property through the type hierarchy
+        /// </summary>
+        /// <param name="type">The type to start searching from</param>
+        /// <param name="propertyName">The name of the property to find</param>
+        /// <returns>The PropertyInfo if found, null otherwise</returns>
+        private PropertyInfo GetPropertyRecursive(Type type, string propertyName)
+        {
+            while (type != null && type != typeof(object))
+            {
+                PropertyInfo prop = type.GetProperty(propertyName, 
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                if (prop != null) 
+                    return prop;
+                type = type.BaseType;
+            }
+            return null;
+        }
         
         /// <summary>
         /// Update component data based on the provided JObject
+        /// Uses SerializedObject API as primary method (handles base class fields and nested paths),
+        /// with reflection as fallback for non-serialized properties.
         /// </summary>
         /// <param name="component">The component to update</param>
         /// <param name="componentData">The data to apply to the component</param>
-        /// <returns>True if the component was updated successfully</returns>
+        /// <param name="errorMessage">Error message if any fields failed to update</param>
+        /// <returns>True if all fields were updated successfully</returns>
         private bool UpdateComponentData(Component component, JObject componentData, out string errorMessage)
         {
             errorMessage = "";
@@ -261,21 +302,36 @@ namespace McpUnity.Tools
             // Record object for undo
             Undo.RecordObject(component, $"Update {componentType.Name} fields");
             
+            // Create SerializedObject for the primary approach
+            SerializedObject serializedObject = new SerializedObject(component);
+            
             // Process each field or property in the component data
             foreach (var property in componentData.Properties())
             {
                 string fieldName = property.Name;
                 JToken fieldValue = property.Value;
                 
-                // Skip null values
-                if (string.IsNullOrEmpty(fieldName) || fieldValue.Type == JTokenType.Null)
+                // Skip null field names
+                if (string.IsNullOrEmpty(fieldName))
                 {
                     continue;
                 }
                 
-                // Try to update field
-                FieldInfo fieldInfo = componentType.GetField(fieldName, 
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                // Primary approach: Try SerializedObject API first
+                // This handles base class fields and nested paths automatically
+                SerializedProperty serializedProperty = serializedObject.FindProperty(fieldName);
+                
+                if (serializedProperty != null)
+                {
+                    SetSerializedPropertyValue(serializedProperty, fieldValue);
+                    continue;
+                }
+                
+                // Fallback: Use reflection with recursive base class search
+                // This handles non-serialized properties that SerializedObject can't access
+                
+                // Try to find field (including in base classes)
+                FieldInfo fieldInfo = GetFieldRecursive(componentType, fieldName);
                     
                 if (fieldInfo != null)
                 {
@@ -284,11 +340,10 @@ namespace McpUnity.Tools
                     continue;
                 }
                 
-                // Try to update property if not found as a field
-                PropertyInfo propertyInfo = componentType.GetProperty(fieldName, 
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                // Try to find property (including in base classes)
+                PropertyInfo propertyInfo = GetPropertyRecursive(componentType, fieldName);
                 
-                if (propertyInfo != null)
+                if (propertyInfo != null && propertyInfo.CanWrite)
                 {
                     object value = ConvertJTokenToValue(fieldValue, propertyInfo.PropertyType);
                     propertyInfo.SetValue(component, value);
@@ -296,10 +351,350 @@ namespace McpUnity.Tools
                 }
                 
                 fullSuccess = false;
-                errorMessage = $"Field or Property  with name '{fieldName}' not found on component '{componentType.Name}'";
+                errorMessage = $"Field or Property with name '{fieldName}' not found on component '{componentType.Name}'";
+                McpLogger.LogWarning($"[MCP Unity] {errorMessage}");
             }
+            
+            // Apply all SerializedObject changes
+            serializedObject.ApplyModifiedProperties();
 
             return fullSuccess;
+        }
+
+        /// <summary>
+        /// Update component data using Unity's SerializedObject API
+        /// This properly handles all serialized fields including private ones in base classes
+        /// </summary>
+        /// <param name="component">The component to update</param>
+        /// <param name="componentData">The data to apply to the component</param>
+        /// <param name="errorMessage">Error message if any fields failed to update</param>
+        /// <returns>True if all fields were updated successfully</returns>
+        private bool UpdateComponentDataSerialized(Component component, JObject componentData, out string errorMessage)
+        {
+            errorMessage = "";
+            SerializedObject serializedObject = new SerializedObject(component);
+            bool allFieldsFound = true;
+            
+            foreach (var property in componentData.Properties())
+            {
+                string fieldPath = property.Name;
+                JToken fieldValue = property.Value;
+                
+                // Skip null values
+                if (string.IsNullOrEmpty(fieldPath) || fieldValue.Type == JTokenType.Null)
+                {
+                    continue;
+                }
+                
+                // SerializedObject.FindProperty uses Unity's serialization path
+                SerializedProperty serializedProperty = serializedObject.FindProperty(fieldPath);
+                
+                if (serializedProperty == null)
+                {
+                    McpLogger.LogWarning($"[MCP Unity] SerializedProperty '{fieldPath}' not found on {component.GetType().Name}");
+                    errorMessage = $"Property '{fieldPath}' not found";
+                    allFieldsFound = false;
+                    continue;
+                }
+                
+                SetSerializedPropertyValue(serializedProperty, fieldValue);
+            }
+            
+            serializedObject.ApplyModifiedProperties();
+            return allFieldsFound;
+        }
+
+        /// <summary>
+        /// Set a SerializedProperty value from a JToken
+        /// </summary>
+        /// <param name="prop">The SerializedProperty to set</param>
+        /// <param name="value">The JToken value to apply</param>
+        private void SetSerializedPropertyValue(SerializedProperty prop, JToken value)
+        {
+            switch (prop.propertyType)
+            {
+                case SerializedPropertyType.Integer:
+                    prop.intValue = value.ToObject<int>();
+                    break;
+                    
+                case SerializedPropertyType.Boolean:
+                    prop.boolValue = value.ToObject<bool>();
+                    break;
+                    
+                case SerializedPropertyType.Float:
+                    prop.floatValue = value.ToObject<float>();
+                    break;
+                    
+                case SerializedPropertyType.String:
+                    prop.stringValue = value.ToObject<string>();
+                    break;
+                    
+                case SerializedPropertyType.Color:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject color = (JObject)value;
+                        prop.colorValue = new Color(
+                            color["r"]?.ToObject<float>() ?? 0f,
+                            color["g"]?.ToObject<float>() ?? 0f,
+                            color["b"]?.ToObject<float>() ?? 0f,
+                            color["a"]?.ToObject<float>() ?? 1f
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.Vector2:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject v2 = (JObject)value;
+                        prop.vector2Value = new Vector2(
+                            v2["x"]?.ToObject<float>() ?? 0f,
+                            v2["y"]?.ToObject<float>() ?? 0f
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.Vector3:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject v3 = (JObject)value;
+                        prop.vector3Value = new Vector3(
+                            v3["x"]?.ToObject<float>() ?? 0f,
+                            v3["y"]?.ToObject<float>() ?? 0f,
+                            v3["z"]?.ToObject<float>() ?? 0f
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.Vector4:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject v4 = (JObject)value;
+                        prop.vector4Value = new Vector4(
+                            v4["x"]?.ToObject<float>() ?? 0f,
+                            v4["y"]?.ToObject<float>() ?? 0f,
+                            v4["z"]?.ToObject<float>() ?? 0f,
+                            v4["w"]?.ToObject<float>() ?? 0f
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.Quaternion:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject q = (JObject)value;
+                        prop.quaternionValue = new Quaternion(
+                            q["x"]?.ToObject<float>() ?? 0f,
+                            q["y"]?.ToObject<float>() ?? 0f,
+                            q["z"]?.ToObject<float>() ?? 0f,
+                            q["w"]?.ToObject<float>() ?? 1f
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.Rect:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject rect = (JObject)value;
+                        prop.rectValue = new Rect(
+                            rect["x"]?.ToObject<float>() ?? 0f,
+                            rect["y"]?.ToObject<float>() ?? 0f,
+                            rect["width"]?.ToObject<float>() ?? 0f,
+                            rect["height"]?.ToObject<float>() ?? 0f
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.Bounds:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject bounds = (JObject)value;
+                        JObject center = bounds["center"] as JObject;
+                        JObject size = bounds["size"] as JObject;
+                        prop.boundsValue = new Bounds(
+                            center != null ? new Vector3(
+                                center["x"]?.ToObject<float>() ?? 0f,
+                                center["y"]?.ToObject<float>() ?? 0f,
+                                center["z"]?.ToObject<float>() ?? 0f
+                            ) : Vector3.zero,
+                            size != null ? new Vector3(
+                                size["x"]?.ToObject<float>() ?? 0f,
+                                size["y"]?.ToObject<float>() ?? 0f,
+                                size["z"]?.ToObject<float>() ?? 0f
+                            ) : Vector3.one
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.Enum:
+                    if (value.Type == JTokenType.String)
+                    {
+                        // Find enum value by name
+                        string[] enumNames = prop.enumNames;
+                        string enumValue = value.ToObject<string>();
+                        int index = Array.IndexOf(enumNames, enumValue);
+                        if (index >= 0)
+                        {
+                            prop.enumValueIndex = index;
+                        }
+                        else
+                        {
+                            // Try case-insensitive match
+                            for (int i = 0; i < enumNames.Length; i++)
+                            {
+                                if (string.Equals(enumNames[i], enumValue, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    prop.enumValueIndex = i;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    else if (value.Type == JTokenType.Integer)
+                    {
+                        prop.enumValueIndex = value.ToObject<int>();
+                    }
+                    break;
+                    
+                case SerializedPropertyType.ObjectReference:
+                    // Handle asset references
+                    if (value.Type == JTokenType.String)
+                    {
+                        string assetPath = value.ToObject<string>();
+                        if (!string.IsNullOrEmpty(assetPath))
+                        {
+                            UnityEngine.Object asset = null;
+                            
+                            // Try to load as asset path
+                            if (assetPath.StartsWith("Assets/") || assetPath.StartsWith("Packages/"))
+                            {
+                                asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
+                            }
+                            
+                            // If not found, try to find by name
+                            if (asset == null)
+                            {
+                                string[] guids = AssetDatabase.FindAssets(assetPath);
+                                if (guids.Length > 0)
+                                {
+                                    string path = AssetDatabase.GUIDToAssetPath(guids[0]);
+                                    asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path);
+                                }
+                            }
+                            
+                            prop.objectReferenceValue = asset;
+                        }
+                        else
+                        {
+                            prop.objectReferenceValue = null;
+                        }
+                    }
+                    else if (value.Type == JTokenType.Object)
+                    {
+                        JObject obj = (JObject)value;
+                        string guid = obj["guid"]?.ToObject<string>();
+                        string path = obj["path"]?.ToObject<string>();
+                        
+                        if (!string.IsNullOrEmpty(guid))
+                        {
+                            path = AssetDatabase.GUIDToAssetPath(guid);
+                        }
+                        
+                        if (!string.IsNullOrEmpty(path))
+                        {
+                            prop.objectReferenceValue = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path);
+                        }
+                    }
+                    else if (value.Type == JTokenType.Null)
+                    {
+                        prop.objectReferenceValue = null;
+                    }
+                    break;
+                    
+                case SerializedPropertyType.LayerMask:
+                    prop.intValue = value.ToObject<int>();
+                    break;
+                    
+                case SerializedPropertyType.Vector2Int:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject v2i = (JObject)value;
+                        prop.vector2IntValue = new Vector2Int(
+                            v2i["x"]?.ToObject<int>() ?? 0,
+                            v2i["y"]?.ToObject<int>() ?? 0
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.Vector3Int:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject v3i = (JObject)value;
+                        prop.vector3IntValue = new Vector3Int(
+                            v3i["x"]?.ToObject<int>() ?? 0,
+                            v3i["y"]?.ToObject<int>() ?? 0,
+                            v3i["z"]?.ToObject<int>() ?? 0
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.RectInt:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject rectInt = (JObject)value;
+                        prop.rectIntValue = new RectInt(
+                            rectInt["x"]?.ToObject<int>() ?? 0,
+                            rectInt["y"]?.ToObject<int>() ?? 0,
+                            rectInt["width"]?.ToObject<int>() ?? 0,
+                            rectInt["height"]?.ToObject<int>() ?? 0
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.BoundsInt:
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject boundsInt = (JObject)value;
+                        JObject position = boundsInt["position"] as JObject;
+                        JObject size = boundsInt["size"] as JObject;
+                        prop.boundsIntValue = new BoundsInt(
+                            position != null ? new Vector3Int(
+                                position["x"]?.ToObject<int>() ?? 0,
+                                position["y"]?.ToObject<int>() ?? 0,
+                                position["z"]?.ToObject<int>() ?? 0
+                            ) : Vector3Int.zero,
+                            size != null ? new Vector3Int(
+                                size["x"]?.ToObject<int>() ?? 0,
+                                size["y"]?.ToObject<int>() ?? 0,
+                                size["z"]?.ToObject<int>() ?? 0
+                            ) : Vector3Int.one
+                        );
+                    }
+                    break;
+                    
+                case SerializedPropertyType.Generic:
+                    // For complex types, try to iterate children
+                    if (value.Type == JTokenType.Object)
+                    {
+                        JObject obj = (JObject)value;
+                        foreach (var child in obj.Properties())
+                        {
+                            SerializedProperty childProp = prop.FindPropertyRelative(child.Name);
+                            if (childProp != null)
+                            {
+                                SetSerializedPropertyValue(childProp, child.Value);
+                            }
+                        }
+                    }
+                    break;
+                    
+                case SerializedPropertyType.ArraySize:
+                    prop.intValue = value.ToObject<int>();
+                    break;
+                    
+                default:
+                    McpLogger.LogWarning($"[MCP Unity] Unsupported property type: {prop.propertyType} for {prop.name}");
+                    break;
+            }
         }
 
         /// <summary>
@@ -387,10 +782,77 @@ namespace McpUnity.Tools
                 );
             }
             
-            // Handle UnityEngine.Object types;
-            if (targetType == typeof(UnityEngine.Object))
+            // Handle UnityEngine.Object types (assets) by path or GUID
+            if (typeof(UnityEngine.Object).IsAssignableFrom(targetType))
             {
-                return token.ToObject<UnityEngine.Object>();
+                if (token.Type == JTokenType.String)
+                {
+                    string assetPath = token.ToObject<string>();
+                    
+                    if (string.IsNullOrEmpty(assetPath))
+                    {
+                        return null;
+                    }
+                    
+                    // Try to load as asset path
+                    if (assetPath.StartsWith("Assets/") || assetPath.StartsWith("Packages/"))
+                    {
+                        UnityEngine.Object asset = AssetDatabase.LoadAssetAtPath(assetPath, targetType);
+                        if (asset != null)
+                        {
+                            return asset;
+                        }
+                        McpLogger.LogWarning($"[MCP Unity] Could not load asset at path: {assetPath}");
+                    }
+                    
+                    // Try to find by name in project
+                    string[] guids = AssetDatabase.FindAssets($"{assetPath} t:{targetType.Name}");
+                    if (guids.Length > 0)
+                    {
+                        string path = AssetDatabase.GUIDToAssetPath(guids[0]);
+                        return AssetDatabase.LoadAssetAtPath(path, targetType);
+                    }
+                    
+                    // Final fallback - search without type filter
+                    guids = AssetDatabase.FindAssets(assetPath);
+                    if (guids.Length > 0)
+                    {
+                        string path = AssetDatabase.GUIDToAssetPath(guids[0]);
+                        UnityEngine.Object asset = AssetDatabase.LoadAssetAtPath(path, targetType);
+                        if (asset != null)
+                        {
+                            return asset;
+                        }
+                    }
+                    
+                    McpLogger.LogWarning($"[MCP Unity] Could not find asset: {assetPath}");
+                    return null;
+                }
+                else if (token.Type == JTokenType.Object)
+                {
+                    // Handle object with guid or path property
+                    JObject obj = (JObject)token;
+                    string guid = obj["guid"]?.ToObject<string>();
+                    string path = obj["path"]?.ToObject<string>();
+                    
+                    if (!string.IsNullOrEmpty(guid))
+                    {
+                        string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                        if (!string.IsNullOrEmpty(assetPath))
+                        {
+                            return AssetDatabase.LoadAssetAtPath(assetPath, targetType);
+                        }
+                        McpLogger.LogWarning($"[MCP Unity] Could not find asset with GUID: {guid}");
+                    }
+                    else if (!string.IsNullOrEmpty(path))
+                    {
+                        return AssetDatabase.LoadAssetAtPath(path, targetType);
+                    }
+                }
+                else if (token.Type == JTokenType.Null)
+                {
+                    return null;
+                }
             }
             
             // Handle enum types

--- a/Editor/Tools/UpdateComponentTool.cs
+++ b/Editor/Tools/UpdateComponentTool.cs
@@ -239,44 +239,40 @@ namespace McpUnity.Tools
             return null;
         }
 
-        /// <summary>
-        /// Recursively search for a field through the type hierarchy
-        /// </summary>
-        /// <param name="type">The type to start searching from</param>
-        /// <param name="fieldName">The name of the field to find</param>
-        /// <returns>The FieldInfo if found, null otherwise</returns>
         private FieldInfo GetFieldRecursive(Type type, string fieldName)
         {
             while (type != null && type != typeof(object))
             {
-                FieldInfo field = type.GetField(fieldName, 
+                FieldInfo field = type.GetField(fieldName,
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-                if (field != null) 
+                if (field != null)
+                {
                     return field;
+                }
+
                 type = type.BaseType;
             }
+
             return null;
         }
 
-        /// <summary>
-        /// Recursively search for a property through the type hierarchy
-        /// </summary>
-        /// <param name="type">The type to start searching from</param>
-        /// <param name="propertyName">The name of the property to find</param>
-        /// <returns>The PropertyInfo if found, null otherwise</returns>
         private PropertyInfo GetPropertyRecursive(Type type, string propertyName)
         {
             while (type != null && type != typeof(object))
             {
-                PropertyInfo prop = type.GetProperty(propertyName, 
+                PropertyInfo prop = type.GetProperty(propertyName,
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-                if (prop != null) 
+                if (prop != null)
+                {
                     return prop;
+                }
+
                 type = type.BaseType;
             }
+
             return null;
         }
-        
+
         /// <summary>
         /// Update component data based on the provided JObject
         /// Uses SerializedObject API as primary method (handles base class fields and nested paths),
@@ -301,399 +297,176 @@ namespace McpUnity.Tools
 
             // Record object for undo
             Undo.RecordObject(component, $"Update {componentType.Name} fields");
-            
-            // Create SerializedObject for the primary approach
+
             SerializedObject serializedObject = new SerializedObject(component);
-            
-            // Process each field or property in the component data
+
             foreach (var property in componentData.Properties())
             {
                 string fieldName = property.Name;
                 JToken fieldValue = property.Value;
-                
-                // Skip null field names
+
                 if (string.IsNullOrEmpty(fieldName))
                 {
                     continue;
                 }
-                
-                // Primary approach: Try SerializedObject API first
-                // This handles base class fields and nested paths automatically
+
                 SerializedProperty serializedProperty = serializedObject.FindProperty(fieldName);
-                
                 if (serializedProperty != null)
                 {
-                    SetSerializedPropertyValue(serializedProperty, fieldValue);
+                    if (!TrySetSerializedPropertyValue(serializedProperty, fieldValue, out string setError))
+                    {
+                        fullSuccess = false;
+                        errorMessage = setError;
+                        McpLogger.LogWarning($"[MCP Unity] {errorMessage}");
+                        break;
+                    }
+
                     continue;
                 }
-                
-                // Fallback: Use reflection with recursive base class search
-                // This handles non-serialized properties that SerializedObject can't access
-                
-                // Try to find field (including in base classes)
+
                 FieldInfo fieldInfo = GetFieldRecursive(componentType, fieldName);
-                    
                 if (fieldInfo != null)
                 {
-                    object value = ConvertJTokenToValue(fieldValue, fieldInfo.FieldType);
+                    if (!TryConvertJTokenToValue(fieldValue, fieldInfo.FieldType, out object value, out string convertError))
+                    {
+                        fullSuccess = false;
+                        errorMessage = $"Could not convert field '{fieldName}' on component '{componentType.Name}': {convertError}";
+                        McpLogger.LogWarning($"[MCP Unity] {errorMessage}");
+                        break;
+                    }
+
                     fieldInfo.SetValue(component, value);
                     continue;
                 }
-                
-                // Try to find property (including in base classes)
+
                 PropertyInfo propertyInfo = GetPropertyRecursive(componentType, fieldName);
-                
-                if (propertyInfo != null && propertyInfo.CanWrite)
+                if (propertyInfo != null)
                 {
-                    object value = ConvertJTokenToValue(fieldValue, propertyInfo.PropertyType);
+                    if (!propertyInfo.CanWrite)
+                    {
+                        fullSuccess = false;
+                        errorMessage = $"Property '{fieldName}' on component '{componentType.Name}' is read-only";
+                        McpLogger.LogWarning($"[MCP Unity] {errorMessage}");
+                        break;
+                    }
+
+                    if (!TryConvertJTokenToValue(fieldValue, propertyInfo.PropertyType, out object value, out string convertError))
+                    {
+                        fullSuccess = false;
+                        errorMessage = $"Could not convert property '{fieldName}' on component '{componentType.Name}': {convertError}";
+                        McpLogger.LogWarning($"[MCP Unity] {errorMessage}");
+                        break;
+                    }
+
                     propertyInfo.SetValue(component, value);
                     continue;
                 }
-                
+
                 fullSuccess = false;
                 errorMessage = $"Field or Property with name '{fieldName}' not found on component '{componentType.Name}'";
                 McpLogger.LogWarning($"[MCP Unity] {errorMessage}");
+                break;
             }
-            
-            // Apply all SerializedObject changes
-            serializedObject.ApplyModifiedProperties();
+
+            if (fullSuccess)
+            {
+                serializedObject.ApplyModifiedProperties();
+            }
 
             return fullSuccess;
         }
 
-        /// <summary>
-        /// Update component data using Unity's SerializedObject API
-        /// This properly handles all serialized fields including private ones in base classes
-        /// </summary>
-        /// <param name="component">The component to update</param>
-        /// <param name="componentData">The data to apply to the component</param>
-        /// <param name="errorMessage">Error message if any fields failed to update</param>
-        /// <returns>True if all fields were updated successfully</returns>
-        private bool UpdateComponentDataSerialized(Component component, JObject componentData, out string errorMessage)
+        private bool TrySetSerializedPropertyValue(SerializedProperty prop, JToken value, out string errorMessage)
         {
             errorMessage = "";
-            SerializedObject serializedObject = new SerializedObject(component);
-            bool allFieldsFound = true;
-            
-            foreach (var property in componentData.Properties())
-            {
-                string fieldPath = property.Name;
-                JToken fieldValue = property.Value;
-                
-                // Skip null values
-                if (string.IsNullOrEmpty(fieldPath) || fieldValue.Type == JTokenType.Null)
-                {
-                    continue;
-                }
-                
-                // SerializedObject.FindProperty uses Unity's serialization path
-                SerializedProperty serializedProperty = serializedObject.FindProperty(fieldPath);
-                
-                if (serializedProperty == null)
-                {
-                    McpLogger.LogWarning($"[MCP Unity] SerializedProperty '{fieldPath}' not found on {component.GetType().Name}");
-                    errorMessage = $"Property '{fieldPath}' not found";
-                    allFieldsFound = false;
-                    continue;
-                }
-                
-                SetSerializedPropertyValue(serializedProperty, fieldValue);
-            }
-            
-            serializedObject.ApplyModifiedProperties();
-            return allFieldsFound;
-        }
 
-        /// <summary>
-        /// Set a SerializedProperty value from a JToken
-        /// </summary>
-        /// <param name="prop">The SerializedProperty to set</param>
-        /// <param name="value">The JToken value to apply</param>
-        private void SetSerializedPropertyValue(SerializedProperty prop, JToken value)
-        {
-            switch (prop.propertyType)
+            try
             {
-                case SerializedPropertyType.Integer:
-                    prop.intValue = value.ToObject<int>();
-                    break;
-                    
-                case SerializedPropertyType.Boolean:
-                    prop.boolValue = value.ToObject<bool>();
-                    break;
-                    
-                case SerializedPropertyType.Float:
-                    prop.floatValue = value.ToObject<float>();
-                    break;
-                    
-                case SerializedPropertyType.String:
-                    prop.stringValue = value.ToObject<string>();
-                    break;
-                    
-                case SerializedPropertyType.Color:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject color = (JObject)value;
-                        prop.colorValue = new Color(
-                            color["r"]?.ToObject<float>() ?? 0f,
-                            color["g"]?.ToObject<float>() ?? 0f,
-                            color["b"]?.ToObject<float>() ?? 0f,
-                            color["a"]?.ToObject<float>() ?? 1f
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.Vector2:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject v2 = (JObject)value;
-                        prop.vector2Value = new Vector2(
-                            v2["x"]?.ToObject<float>() ?? 0f,
-                            v2["y"]?.ToObject<float>() ?? 0f
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.Vector3:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject v3 = (JObject)value;
-                        prop.vector3Value = new Vector3(
-                            v3["x"]?.ToObject<float>() ?? 0f,
-                            v3["y"]?.ToObject<float>() ?? 0f,
-                            v3["z"]?.ToObject<float>() ?? 0f
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.Vector4:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject v4 = (JObject)value;
-                        prop.vector4Value = new Vector4(
-                            v4["x"]?.ToObject<float>() ?? 0f,
-                            v4["y"]?.ToObject<float>() ?? 0f,
-                            v4["z"]?.ToObject<float>() ?? 0f,
-                            v4["w"]?.ToObject<float>() ?? 0f
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.Quaternion:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject q = (JObject)value;
-                        prop.quaternionValue = new Quaternion(
-                            q["x"]?.ToObject<float>() ?? 0f,
-                            q["y"]?.ToObject<float>() ?? 0f,
-                            q["z"]?.ToObject<float>() ?? 0f,
-                            q["w"]?.ToObject<float>() ?? 1f
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.Rect:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject rect = (JObject)value;
-                        prop.rectValue = new Rect(
-                            rect["x"]?.ToObject<float>() ?? 0f,
-                            rect["y"]?.ToObject<float>() ?? 0f,
-                            rect["width"]?.ToObject<float>() ?? 0f,
-                            rect["height"]?.ToObject<float>() ?? 0f
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.Bounds:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject bounds = (JObject)value;
-                        JObject center = bounds["center"] as JObject;
-                        JObject size = bounds["size"] as JObject;
-                        prop.boundsValue = new Bounds(
-                            center != null ? new Vector3(
-                                center["x"]?.ToObject<float>() ?? 0f,
-                                center["y"]?.ToObject<float>() ?? 0f,
-                                center["z"]?.ToObject<float>() ?? 0f
-                            ) : Vector3.zero,
-                            size != null ? new Vector3(
-                                size["x"]?.ToObject<float>() ?? 0f,
-                                size["y"]?.ToObject<float>() ?? 0f,
-                                size["z"]?.ToObject<float>() ?? 0f
-                            ) : Vector3.one
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.Enum:
-                    if (value.Type == JTokenType.String)
-                    {
-                        // Find enum value by name
-                        string[] enumNames = prop.enumNames;
-                        string enumValue = value.ToObject<string>();
-                        int index = Array.IndexOf(enumNames, enumValue);
-                        if (index >= 0)
+                switch (prop.propertyType)
+                {
+                    case SerializedPropertyType.Integer:
+                        prop.intValue = value.ToObject<int>();
+                        return true;
+                    case SerializedPropertyType.Boolean:
+                        prop.boolValue = value.ToObject<bool>();
+                        return true;
+                    case SerializedPropertyType.Float:
+                        prop.floatValue = value.ToObject<float>();
+                        return true;
+                    case SerializedPropertyType.String:
+                        prop.stringValue = value.Type == JTokenType.Null ? null : value.ToObject<string>();
+                        return true;
+                    case SerializedPropertyType.Color:
+                        if (!TryReadColor(value, out Color color, out errorMessage)) return false;
+                        prop.colorValue = color;
+                        return true;
+                    case SerializedPropertyType.Vector2:
+                        if (!TryReadVector2(value, out Vector2 vector2, out errorMessage)) return false;
+                        prop.vector2Value = vector2;
+                        return true;
+                    case SerializedPropertyType.Vector3:
+                        if (!TryReadVector3(value, out Vector3 vector3, out errorMessage)) return false;
+                        prop.vector3Value = vector3;
+                        return true;
+                    case SerializedPropertyType.Vector4:
+                        if (!TryReadVector4(value, out Vector4 vector4, out errorMessage)) return false;
+                        prop.vector4Value = vector4;
+                        return true;
+                    case SerializedPropertyType.Quaternion:
+                        if (!TryReadQuaternion(value, out Quaternion quaternion, out errorMessage)) return false;
+                        prop.quaternionValue = quaternion;
+                        return true;
+                    case SerializedPropertyType.Rect:
+                        if (!TryReadRect(value, out Rect rect, out errorMessage)) return false;
+                        prop.rectValue = rect;
+                        return true;
+                    case SerializedPropertyType.Bounds:
+                        if (!TryReadBounds(value, out Bounds bounds, out errorMessage)) return false;
+                        prop.boundsValue = bounds;
+                        return true;
+                    case SerializedPropertyType.Enum:
+                        return TrySetEnumProperty(prop, value, out errorMessage);
+                    case SerializedPropertyType.ObjectReference:
+                        if (!TryLoadObjectReference(value, typeof(UnityEngine.Object), out UnityEngine.Object asset, out errorMessage))
                         {
-                            prop.enumValueIndex = index;
+                            return false;
                         }
-                        else
-                        {
-                            // Try case-insensitive match
-                            for (int i = 0; i < enumNames.Length; i++)
-                            {
-                                if (string.Equals(enumNames[i], enumValue, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    prop.enumValueIndex = i;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    else if (value.Type == JTokenType.Integer)
-                    {
-                        prop.enumValueIndex = value.ToObject<int>();
-                    }
-                    break;
-                    
-                case SerializedPropertyType.ObjectReference:
-                    // Handle asset references
-                    if (value.Type == JTokenType.String)
-                    {
-                        string assetPath = value.ToObject<string>();
-                        if (!string.IsNullOrEmpty(assetPath))
-                        {
-                            UnityEngine.Object asset = null;
-                            
-                            // Try to load as asset path
-                            if (assetPath.StartsWith("Assets/") || assetPath.StartsWith("Packages/"))
-                            {
-                                asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
-                            }
-                            
-                            // If not found, try to find by name
-                            if (asset == null)
-                            {
-                                string[] guids = AssetDatabase.FindAssets(assetPath);
-                                if (guids.Length > 0)
-                                {
-                                    string path = AssetDatabase.GUIDToAssetPath(guids[0]);
-                                    asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path);
-                                }
-                            }
-                            
-                            prop.objectReferenceValue = asset;
-                        }
-                        else
-                        {
-                            prop.objectReferenceValue = null;
-                        }
-                    }
-                    else if (value.Type == JTokenType.Object)
-                    {
-                        JObject obj = (JObject)value;
-                        string guid = obj["guid"]?.ToObject<string>();
-                        string path = obj["path"]?.ToObject<string>();
-                        
-                        if (!string.IsNullOrEmpty(guid))
-                        {
-                            path = AssetDatabase.GUIDToAssetPath(guid);
-                        }
-                        
-                        if (!string.IsNullOrEmpty(path))
-                        {
-                            prop.objectReferenceValue = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path);
-                        }
-                    }
-                    else if (value.Type == JTokenType.Null)
-                    {
-                        prop.objectReferenceValue = null;
-                    }
-                    break;
-                    
-                case SerializedPropertyType.LayerMask:
-                    prop.intValue = value.ToObject<int>();
-                    break;
-                    
-                case SerializedPropertyType.Vector2Int:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject v2i = (JObject)value;
-                        prop.vector2IntValue = new Vector2Int(
-                            v2i["x"]?.ToObject<int>() ?? 0,
-                            v2i["y"]?.ToObject<int>() ?? 0
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.Vector3Int:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject v3i = (JObject)value;
-                        prop.vector3IntValue = new Vector3Int(
-                            v3i["x"]?.ToObject<int>() ?? 0,
-                            v3i["y"]?.ToObject<int>() ?? 0,
-                            v3i["z"]?.ToObject<int>() ?? 0
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.RectInt:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject rectInt = (JObject)value;
-                        prop.rectIntValue = new RectInt(
-                            rectInt["x"]?.ToObject<int>() ?? 0,
-                            rectInt["y"]?.ToObject<int>() ?? 0,
-                            rectInt["width"]?.ToObject<int>() ?? 0,
-                            rectInt["height"]?.ToObject<int>() ?? 0
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.BoundsInt:
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject boundsInt = (JObject)value;
-                        JObject position = boundsInt["position"] as JObject;
-                        JObject size = boundsInt["size"] as JObject;
-                        prop.boundsIntValue = new BoundsInt(
-                            position != null ? new Vector3Int(
-                                position["x"]?.ToObject<int>() ?? 0,
-                                position["y"]?.ToObject<int>() ?? 0,
-                                position["z"]?.ToObject<int>() ?? 0
-                            ) : Vector3Int.zero,
-                            size != null ? new Vector3Int(
-                                size["x"]?.ToObject<int>() ?? 0,
-                                size["y"]?.ToObject<int>() ?? 0,
-                                size["z"]?.ToObject<int>() ?? 0
-                            ) : Vector3Int.one
-                        );
-                    }
-                    break;
-                    
-                case SerializedPropertyType.Generic:
-                    // For complex types, try to iterate children
-                    if (value.Type == JTokenType.Object)
-                    {
-                        JObject obj = (JObject)value;
-                        foreach (var child in obj.Properties())
-                        {
-                            SerializedProperty childProp = prop.FindPropertyRelative(child.Name);
-                            if (childProp != null)
-                            {
-                                SetSerializedPropertyValue(childProp, child.Value);
-                            }
-                        }
-                    }
-                    break;
-                    
-                case SerializedPropertyType.ArraySize:
-                    prop.intValue = value.ToObject<int>();
-                    break;
-                    
-                default:
-                    McpLogger.LogWarning($"[MCP Unity] Unsupported property type: {prop.propertyType} for {prop.name}");
-                    break;
+
+                        prop.objectReferenceValue = asset;
+                        return true;
+                    case SerializedPropertyType.LayerMask:
+                        prop.intValue = value.ToObject<int>();
+                        return true;
+                    case SerializedPropertyType.Vector2Int:
+                        if (!TryReadVector2Int(value, out Vector2Int vector2Int, out errorMessage)) return false;
+                        prop.vector2IntValue = vector2Int;
+                        return true;
+                    case SerializedPropertyType.Vector3Int:
+                        if (!TryReadVector3Int(value, out Vector3Int vector3Int, out errorMessage)) return false;
+                        prop.vector3IntValue = vector3Int;
+                        return true;
+                    case SerializedPropertyType.RectInt:
+                        if (!TryReadRectInt(value, out RectInt rectInt, out errorMessage)) return false;
+                        prop.rectIntValue = rectInt;
+                        return true;
+                    case SerializedPropertyType.BoundsInt:
+                        if (!TryReadBoundsInt(value, out BoundsInt boundsInt, out errorMessage)) return false;
+                        prop.boundsIntValue = boundsInt;
+                        return true;
+                    case SerializedPropertyType.Generic:
+                        return TrySetGenericProperty(prop, value, out errorMessage);
+                    case SerializedPropertyType.ArraySize:
+                        prop.intValue = value.ToObject<int>();
+                        return true;
+                    default:
+                        errorMessage = $"Unsupported property type '{prop.propertyType}' for '{prop.propertyPath}'";
+                        return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"Could not set '{prop.propertyPath}' ({prop.propertyType}): {ex.Message}";
+                return false;
             }
         }
 
@@ -703,193 +476,383 @@ namespace McpUnity.Tools
         /// <param name="token">The JToken to convert</param>
         /// <param name="targetType">The target type to convert to</param>
         /// <returns>The converted value</returns>
-        private object ConvertJTokenToValue(JToken token, Type targetType)
+        private bool TryConvertJTokenToValue(JToken token, Type targetType, out object value, out string errorMessage)
         {
-            if (token == null)
+            value = null;
+            errorMessage = "";
+
+            if (token == null || token.Type == JTokenType.Null)
             {
-                return null;
+                if (targetType.IsValueType && Nullable.GetUnderlyingType(targetType) == null)
+                {
+                    errorMessage = $"Cannot assign null to value type '{targetType.Name}'";
+                    return false;
+                }
+
+                return true;
             }
-            
+
             // Handle Unity Vector types
             if (targetType == typeof(Vector2) && token.Type == JTokenType.Object)
             {
-                JObject vector = (JObject)token;
-                return new Vector2(
-                    vector["x"]?.ToObject<float>() ?? 0f,
-                    vector["y"]?.ToObject<float>() ?? 0f
-                );
+                bool success = TryReadVector2(token, out Vector2 vector, out errorMessage);
+                value = vector;
+                return success;
             }
-            
+
             if (targetType == typeof(Vector3) && token.Type == JTokenType.Object)
             {
-                JObject vector = (JObject)token;
-                return new Vector3(
-                    vector["x"]?.ToObject<float>() ?? 0f,
-                    vector["y"]?.ToObject<float>() ?? 0f,
-                    vector["z"]?.ToObject<float>() ?? 0f
-                );
+                bool success = TryReadVector3(token, out Vector3 vector, out errorMessage);
+                value = vector;
+                return success;
             }
-            
+
             if (targetType == typeof(Vector4) && token.Type == JTokenType.Object)
             {
-                JObject vector = (JObject)token;
-                return new Vector4(
-                    vector["x"]?.ToObject<float>() ?? 0f,
-                    vector["y"]?.ToObject<float>() ?? 0f,
-                    vector["z"]?.ToObject<float>() ?? 0f,
-                    vector["w"]?.ToObject<float>() ?? 0f
-                );
+                bool success = TryReadVector4(token, out Vector4 vector, out errorMessage);
+                value = vector;
+                return success;
             }
-            
+
             if (targetType == typeof(Quaternion) && token.Type == JTokenType.Object)
             {
-                JObject quaternion = (JObject)token;
-                return new Quaternion(
-                    quaternion["x"]?.ToObject<float>() ?? 0f,
-                    quaternion["y"]?.ToObject<float>() ?? 0f,
-                    quaternion["z"]?.ToObject<float>() ?? 0f,
-                    quaternion["w"]?.ToObject<float>() ?? 1f
-                );
+                bool success = TryReadQuaternion(token, out Quaternion quaternion, out errorMessage);
+                value = quaternion;
+                return success;
             }
-            
+
             if (targetType == typeof(Color) && token.Type == JTokenType.Object)
             {
-                JObject color = (JObject)token;
-                return new Color(
-                    color["r"]?.ToObject<float>() ?? 0f,
-                    color["g"]?.ToObject<float>() ?? 0f,
-                    color["b"]?.ToObject<float>() ?? 0f,
-                    color["a"]?.ToObject<float>() ?? 1f
-                );
+                bool success = TryReadColor(token, out Color color, out errorMessage);
+                value = color;
+                return success;
             }
-            
+
             if (targetType == typeof(Bounds) && token.Type == JTokenType.Object)
             {
-                JObject bounds = (JObject)token;
-                Vector3 center = bounds["center"]?.ToObject<Vector3>() ?? Vector3.zero;
-                Vector3 size = bounds["size"]?.ToObject<Vector3>() ?? Vector3.one;
-                return new Bounds(center, size);
+                bool success = TryReadBounds(token, out Bounds bounds, out errorMessage);
+                value = bounds;
+                return success;
             }
-            
+
             if (targetType == typeof(Rect) && token.Type == JTokenType.Object)
             {
-                JObject rect = (JObject)token;
-                return new Rect(
-                    rect["x"]?.ToObject<float>() ?? 0f,
-                    rect["y"]?.ToObject<float>() ?? 0f,
-                    rect["width"]?.ToObject<float>() ?? 0f,
-                    rect["height"]?.ToObject<float>() ?? 0f
-                );
+                bool success = TryReadRect(token, out Rect rect, out errorMessage);
+                value = rect;
+                return success;
             }
-            
+
             // Handle UnityEngine.Object types (assets) by path or GUID
             if (typeof(UnityEngine.Object).IsAssignableFrom(targetType))
             {
-                if (token.Type == JTokenType.String)
-                {
-                    string assetPath = token.ToObject<string>();
-                    
-                    if (string.IsNullOrEmpty(assetPath))
-                    {
-                        return null;
-                    }
-                    
-                    // Try to load as asset path
-                    if (assetPath.StartsWith("Assets/") || assetPath.StartsWith("Packages/"))
-                    {
-                        UnityEngine.Object asset = AssetDatabase.LoadAssetAtPath(assetPath, targetType);
-                        if (asset != null)
-                        {
-                            return asset;
-                        }
-                        McpLogger.LogWarning($"[MCP Unity] Could not load asset at path: {assetPath}");
-                    }
-                    
-                    // Try to find by name in project
-                    string[] guids = AssetDatabase.FindAssets($"{assetPath} t:{targetType.Name}");
-                    if (guids.Length > 0)
-                    {
-                        string path = AssetDatabase.GUIDToAssetPath(guids[0]);
-                        return AssetDatabase.LoadAssetAtPath(path, targetType);
-                    }
-                    
-                    // Final fallback - search without type filter
-                    guids = AssetDatabase.FindAssets(assetPath);
-                    if (guids.Length > 0)
-                    {
-                        string path = AssetDatabase.GUIDToAssetPath(guids[0]);
-                        UnityEngine.Object asset = AssetDatabase.LoadAssetAtPath(path, targetType);
-                        if (asset != null)
-                        {
-                            return asset;
-                        }
-                    }
-                    
-                    McpLogger.LogWarning($"[MCP Unity] Could not find asset: {assetPath}");
-                    return null;
-                }
-                else if (token.Type == JTokenType.Object)
-                {
-                    // Handle object with guid or path property
-                    JObject obj = (JObject)token;
-                    string guid = obj["guid"]?.ToObject<string>();
-                    string path = obj["path"]?.ToObject<string>();
-                    
-                    if (!string.IsNullOrEmpty(guid))
-                    {
-                        string assetPath = AssetDatabase.GUIDToAssetPath(guid);
-                        if (!string.IsNullOrEmpty(assetPath))
-                        {
-                            return AssetDatabase.LoadAssetAtPath(assetPath, targetType);
-                        }
-                        McpLogger.LogWarning($"[MCP Unity] Could not find asset with GUID: {guid}");
-                    }
-                    else if (!string.IsNullOrEmpty(path))
-                    {
-                        return AssetDatabase.LoadAssetAtPath(path, targetType);
-                    }
-                }
-                else if (token.Type == JTokenType.Null)
-                {
-                    return null;
-                }
+                bool success = TryLoadObjectReference(token, targetType, out UnityEngine.Object asset, out errorMessage);
+                value = asset;
+                return success;
             }
-            
+
             // Handle enum types
             if (targetType.IsEnum)
             {
-                // If JToken is a string, try to parse as enum name
                 if (token.Type == JTokenType.String)
                 {
                     string enumName = token.ToObject<string>();
                     if (Enum.TryParse(targetType, enumName, true, out object result))
                     {
-                        return result;
+                        value = result;
+                        return true;
                     }
-                    
-                    // If parsing fails, try to convert numeric value
+
                     if (int.TryParse(enumName, out int enumValue))
                     {
-                        return Enum.ToObject(targetType, enumValue);
+                        value = Enum.ToObject(targetType, enumValue);
+                        return true;
                     }
+
+                    errorMessage = $"'{enumName}' is not a valid value for enum '{targetType.Name}'";
+                    return false;
                 }
-                // If JToken is a number, convert directly to enum
-                else if (token.Type == JTokenType.Integer)
+
+                if (token.Type == JTokenType.Integer)
                 {
-                    return Enum.ToObject(targetType, token.ToObject<int>());
+                    value = Enum.ToObject(targetType, token.ToObject<int>());
+                    return true;
                 }
+
+                errorMessage = $"Expected string or integer for enum '{targetType.Name}'";
+                return false;
             }
-            
-            // For other types, use JToken's ToObject method
+
             try
             {
-                return token.ToObject(targetType);
+                value = token.ToObject(targetType);
+                return true;
             }
             catch (Exception ex)
             {
-                McpLogger.LogError($"[MCP Unity] Error converting value to type {targetType.Name}: {ex.Message}");
-                return null;
+                errorMessage = $"Error converting value to type {targetType.Name}: {ex.Message}";
+                return false;
             }
+        }
+
+        private bool TrySetGenericProperty(SerializedProperty prop, JToken value, out string errorMessage)
+        {
+            errorMessage = "";
+
+            if (value.Type != JTokenType.Object)
+            {
+                errorMessage = $"Expected object value for '{prop.propertyPath}'";
+                return false;
+            }
+
+            foreach (var child in ((JObject)value).Properties())
+            {
+                SerializedProperty childProp = prop.FindPropertyRelative(child.Name);
+                if (childProp == null)
+                {
+                    errorMessage = $"Nested property '{child.Name}' not found under '{prop.propertyPath}'";
+                    return false;
+                }
+
+                if (!TrySetSerializedPropertyValue(childProp, child.Value, out errorMessage))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool TrySetEnumProperty(SerializedProperty prop, JToken value, out string errorMessage)
+        {
+            errorMessage = "";
+
+            if (value.Type == JTokenType.String)
+            {
+                string enumValue = value.ToObject<string>();
+                string[] enumNames = prop.enumNames;
+
+                for (int i = 0; i < enumNames.Length; i++)
+                {
+                    if (string.Equals(enumNames[i], enumValue, StringComparison.OrdinalIgnoreCase))
+                    {
+                        prop.enumValueIndex = i;
+                        return true;
+                    }
+                }
+
+                errorMessage = $"'{enumValue}' is not a valid value for '{prop.propertyPath}'";
+                return false;
+            }
+
+            if (value.Type == JTokenType.Integer)
+            {
+                int index = value.ToObject<int>();
+                if (index < 0 || index >= prop.enumNames.Length)
+                {
+                    errorMessage = $"Enum index {index} is out of range for '{prop.propertyPath}'";
+                    return false;
+                }
+
+                prop.enumValueIndex = index;
+                return true;
+            }
+
+            errorMessage = $"Expected string or integer enum value for '{prop.propertyPath}'";
+            return false;
+        }
+
+        private bool TryLoadObjectReference(JToken token, Type targetType, out UnityEngine.Object asset, out string errorMessage)
+        {
+            asset = null;
+            errorMessage = "";
+
+            if (token == null || token.Type == JTokenType.Null)
+            {
+                return true;
+            }
+
+            string assetPath = null;
+
+            if (token.Type == JTokenType.String)
+            {
+                string input = token.ToObject<string>();
+                if (string.IsNullOrEmpty(input))
+                {
+                    return true;
+                }
+
+                if (input.StartsWith("Assets/") || input.StartsWith("Packages/"))
+                {
+                    assetPath = input;
+                }
+                else
+                {
+                    string[] guids = AssetDatabase.FindAssets($"{input} t:{targetType.Name}");
+                    if (guids.Length == 0)
+                    {
+                        guids = AssetDatabase.FindAssets(input);
+                    }
+
+                    if (guids.Length > 0)
+                    {
+                        assetPath = AssetDatabase.GUIDToAssetPath(guids[0]);
+                    }
+                }
+            }
+            else if (token.Type == JTokenType.Object)
+            {
+                JObject obj = (JObject)token;
+                string guid = obj["guid"]?.ToObject<string>();
+                string path = obj["path"]?.ToObject<string>();
+
+                if (!string.IsNullOrEmpty(guid))
+                {
+                    assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                    if (string.IsNullOrEmpty(assetPath))
+                    {
+                        errorMessage = $"Could not find asset with GUID '{guid}'";
+                        return false;
+                    }
+                }
+                else
+                {
+                    assetPath = path;
+                }
+            }
+            else
+            {
+                errorMessage = "Object references must be null, an asset path, an asset name, or an object with guid/path";
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(assetPath))
+            {
+                errorMessage = $"Could not find asset '{token}'";
+                return false;
+            }
+
+            asset = AssetDatabase.LoadAssetAtPath(assetPath, targetType);
+            if (asset == null)
+            {
+                errorMessage = $"Could not find asset at path '{assetPath}'";
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool TryReadObject(JToken value, string expectedType, out JObject obj, out string errorMessage)
+        {
+            obj = value as JObject;
+            errorMessage = "";
+
+            if (obj != null)
+            {
+                return true;
+            }
+
+            errorMessage = $"Expected object value for {expectedType}";
+            return false;
+        }
+
+        private static bool TryReadVector2(JToken value, out Vector2 vector, out string errorMessage)
+        {
+            vector = Vector2.zero;
+            if (!TryReadObject(value, "Vector2", out JObject obj, out errorMessage)) return false;
+            vector = new Vector2(obj["x"]?.ToObject<float>() ?? 0f, obj["y"]?.ToObject<float>() ?? 0f);
+            return true;
+        }
+
+        private static bool TryReadVector3(JToken value, out Vector3 vector, out string errorMessage)
+        {
+            vector = Vector3.zero;
+            if (!TryReadObject(value, "Vector3", out JObject obj, out errorMessage)) return false;
+            vector = new Vector3(obj["x"]?.ToObject<float>() ?? 0f, obj["y"]?.ToObject<float>() ?? 0f, obj["z"]?.ToObject<float>() ?? 0f);
+            return true;
+        }
+
+        private static bool TryReadVector4(JToken value, out Vector4 vector, out string errorMessage)
+        {
+            vector = Vector4.zero;
+            if (!TryReadObject(value, "Vector4", out JObject obj, out errorMessage)) return false;
+            vector = new Vector4(obj["x"]?.ToObject<float>() ?? 0f, obj["y"]?.ToObject<float>() ?? 0f, obj["z"]?.ToObject<float>() ?? 0f, obj["w"]?.ToObject<float>() ?? 0f);
+            return true;
+        }
+
+        private static bool TryReadQuaternion(JToken value, out Quaternion quaternion, out string errorMessage)
+        {
+            quaternion = Quaternion.identity;
+            if (!TryReadObject(value, "Quaternion", out JObject obj, out errorMessage)) return false;
+            quaternion = new Quaternion(obj["x"]?.ToObject<float>() ?? 0f, obj["y"]?.ToObject<float>() ?? 0f, obj["z"]?.ToObject<float>() ?? 0f, obj["w"]?.ToObject<float>() ?? 1f);
+            return true;
+        }
+
+        private static bool TryReadColor(JToken value, out Color color, out string errorMessage)
+        {
+            color = Color.clear;
+            if (!TryReadObject(value, "Color", out JObject obj, out errorMessage)) return false;
+            color = new Color(obj["r"]?.ToObject<float>() ?? 0f, obj["g"]?.ToObject<float>() ?? 0f, obj["b"]?.ToObject<float>() ?? 0f, obj["a"]?.ToObject<float>() ?? 1f);
+            return true;
+        }
+
+        private static bool TryReadRect(JToken value, out Rect rect, out string errorMessage)
+        {
+            rect = new Rect();
+            if (!TryReadObject(value, "Rect", out JObject obj, out errorMessage)) return false;
+            rect = new Rect(obj["x"]?.ToObject<float>() ?? 0f, obj["y"]?.ToObject<float>() ?? 0f, obj["width"]?.ToObject<float>() ?? 0f, obj["height"]?.ToObject<float>() ?? 0f);
+            return true;
+        }
+
+        private static bool TryReadBounds(JToken value, out Bounds bounds, out string errorMessage)
+        {
+            bounds = new Bounds(Vector3.zero, Vector3.one);
+            if (!TryReadObject(value, "Bounds", out JObject obj, out errorMessage)) return false;
+
+            Vector3 center = Vector3.zero;
+            Vector3 size = Vector3.one;
+            if (obj["center"] != null && !TryReadVector3(obj["center"], out center, out errorMessage)) return false;
+            if (obj["size"] != null && !TryReadVector3(obj["size"], out size, out errorMessage)) return false;
+
+            bounds = new Bounds(center, size);
+            return true;
+        }
+
+        private static bool TryReadVector2Int(JToken value, out Vector2Int vector, out string errorMessage)
+        {
+            vector = Vector2Int.zero;
+            if (!TryReadObject(value, "Vector2Int", out JObject obj, out errorMessage)) return false;
+            vector = new Vector2Int(obj["x"]?.ToObject<int>() ?? 0, obj["y"]?.ToObject<int>() ?? 0);
+            return true;
+        }
+
+        private static bool TryReadVector3Int(JToken value, out Vector3Int vector, out string errorMessage)
+        {
+            vector = Vector3Int.zero;
+            if (!TryReadObject(value, "Vector3Int", out JObject obj, out errorMessage)) return false;
+            vector = new Vector3Int(obj["x"]?.ToObject<int>() ?? 0, obj["y"]?.ToObject<int>() ?? 0, obj["z"]?.ToObject<int>() ?? 0);
+            return true;
+        }
+
+        private static bool TryReadRectInt(JToken value, out RectInt rect, out string errorMessage)
+        {
+            rect = new RectInt();
+            if (!TryReadObject(value, "RectInt", out JObject obj, out errorMessage)) return false;
+            rect = new RectInt(obj["x"]?.ToObject<int>() ?? 0, obj["y"]?.ToObject<int>() ?? 0, obj["width"]?.ToObject<int>() ?? 0, obj["height"]?.ToObject<int>() ?? 0);
+            return true;
+        }
+
+        private static bool TryReadBoundsInt(JToken value, out BoundsInt bounds, out string errorMessage)
+        {
+            bounds = new BoundsInt(Vector3Int.zero, Vector3Int.one);
+            if (!TryReadObject(value, "BoundsInt", out JObject obj, out errorMessage)) return false;
+
+            Vector3Int position = Vector3Int.zero;
+            Vector3Int size = Vector3Int.one;
+            if (obj["position"] != null && !TryReadVector3Int(obj["position"], out position, out errorMessage)) return false;
+            if (obj["size"] != null && !TryReadVector3Int(obj["size"], out size, out errorMessage)) return false;
+
+            bounds = new BoundsInt(position, size);
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Problem

The `update_component` tool fails when trying to modify:

1. **Asset references** - ScriptableObjects cannot be set by path or GUID
2. **Nested fields** - dot-notation paths like `_eventReference._event` are unsupported
3. **Private serialized fields in base classes** - we're not searching the inheritance hierarchy

Root cause: `GetField()` only searches the immediate type, and the existing `UnityEngine.Object` handler doesn't load assets.

## Solution

Hybrid approach using **SerializedObject API** as primary, with **enhanced reflection** as fallback:

- `SerializedObject.FindProperty()` automatically handles base class fields and nested paths
- New `GetFieldRecursive()` / `GetPropertyRecursive()` helpers traverse the type hierarchy for non-serialized properties
- `SetSerializedPropertyValue()` handles all `SerializedPropertyType` cases including `ObjectReference` with asset path/GUID support
- `ConvertJTokenToValue()` updated to load assets by path (`Assets/...`), GUID (`{guid: "..."}`), or name search

## Usage Examples

```json
// Asset by path
{"_eventReference._event": "Assets/Events/MyEvent.asset"}

// Asset by GUID
{"_eventReference._event": {"guid": "95c910ab954254d98a9165e47e87ec9f"}}
```
