### PR TITLE
fix: iterate over all scenes in GetScenesHierarchyResource

### DIFF
--- a/Editor/Resources/GetScenesHierarchyResource.cs
+++ b/Editor/Resources/GetScenesHierarchyResource.cs
@@ -49,10 +49,15 @@ public class GetScenesHierarchyResource : McpResourceBase
             JArray rootObjectsArray = new JArray();
             
             // Get all loaded scenes
-            int sceneCount = SceneManager.loadedSceneCount;
+            int sceneCount = SceneManager.sceneCount;
             for (int i = 0; i < sceneCount; i++)
             {
                 Scene scene = SceneManager.GetSceneAt(i);
+
+                if (scene.isLoaded == false)
+                {
+                    continue;
+                }
                 
                 // Create a scene object
                 JObject sceneObject = new JObject


### PR DESCRIPTION
GetScenesHierarchyResource had an issue that would potentially lead to missing some of the scenes if invoked during the scene loading/unloading process.

[SceneManager.GetSceneAt ](https://docs.unity3d.com/6000.5/Documentation/ScriptReference/SceneManagement.SceneManager.GetSceneAt.html) indexes into a full list of scenes, which contains both loaded, loading and unloading scenes. [SceneManager.loadedSceneCount](https://docs.unity3d.com/6000.5/Documentation/ScriptReference/SceneManagement.SceneManager-loadedSceneCount.html) only contains the number of loaded scenes, which can be lower than [SceneManager.sceneCount](https://docs.unity3d.com/6000.5/Documentation/ScriptReference/SceneManagement.SceneManager-sceneCount.html), causing the loop to skip scenes at higher indices.