### PR TITLE
fix: fixes mcp unity settings path

### DIFF
--- a/Server~/src/unity/mcpUnity.ts
+++ b/Server~/src/unity/mcpUnity.ts
@@ -7,7 +7,7 @@ import { UnityConnection, ConnectionState, ConnectionStateChange, UnityConnectio
 import { CommandQueue, CommandQueueConfig, CommandQueueStats, QueuedCommand } from './commandQueue.js';
 
 // Top-level constant for the Unity settings JSON path
-const MCP_UNITY_SETTINGS_PATH = path.resolve(process.cwd(), '../ProjectSettings/McpUnitySettings.json');
+const MCP_UNITY_SETTINGS_PATH = path.resolve(process.cwd(), './ProjectSettings/McpUnitySettings.json');
 
 interface PendingRequest {
   resolve: (value: any) => void;


### PR DESCRIPTION
### Problem
When using Claude Code and selecting a project, the `process.cwd()` path will be the root of the Unity project resulting in `../ProjectSettings` going one level above the root of the project.

### Solution
Switching `../ProjectSettings` to `./ProjectSettings` will now find the folder at the root of the Unity project.