### PR TITLE
fix: add missing meta file for test script

### DIFF
--- a/Editor/Tests/GetGameObjectResourceTests.cs.meta
+++ b/Editor/Tests/GetGameObjectResourceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 39bf5230f41fca248bc5d5e164c9c42a


### PR DESCRIPTION
The GetGameObjectResourceTests.cs.meta file was missing, which caused errors when importing the package via Git URL in Unity due to the immutable nature of the PackageCache folder.