### PR TITLE
fix: add missing .meta file for GetGameObjectResourceTests.cs

### DIFF
--- a/Editor/Tests/GetGameObjectResourceTests.cs.meta
+++ b/Editor/Tests/GetGameObjectResourceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6


### PR DESCRIPTION
## Summary

- `Editor/Tests/GetGameObjectResourceTests.cs` was missing its `.meta` file while all other test files (`BatchExecuteToolTests.cs`, `MaterialToolsTests.cs`, `PathHandlingTests.cs`) had theirs.
- This causes Unity to log the following warning every time the editor loads the package:
  ```
  Asset Packages/com.gamelovers.mcp-unity/Editor/Tests/GetGameObjectResourceTests.cs has no meta file, but it's in an immutable folder. The asset will be ignored.
  ```

## Fix

Added the missing `GetGameObjectResourceTests.cs.meta` with a unique GUID, matching the format of the other `.meta` files in the same directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)