### PR TITLE
Update GUID in GetGameObjectResourceTests meta file

### DIFF
--- a/Editor/Tests/GetGameObjectResourceTests.cs.meta
+++ b/Editor/Tests/GetGameObjectResourceTests.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+guid: 97b7ccdbc03964341937c2f49e6a2186


### PR DESCRIPTION
Fixes #132 GUID collision with Meta XR SDK and Unity's AI assistant package (`com.unity.ai.assistant`)

I just generated a new GUID and put it in here. Tested locally and it resolved the issue.