### PR TITLE
fix(editor): dispatch WebSocket OnMessage on Unity main thread

### DIFF
--- a/Editor/UnityBridge/McpUnitySocketHandler.cs
+++ b/Editor/UnityBridge/McpUnitySocketHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using UnityEditor;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using WebSocketSharp;
@@ -51,21 +52,39 @@ namespace McpUnity.Unity
         }
         
         /// <summary>
-        /// Handle incoming messages from WebSocket clients
+        /// Handle incoming messages from WebSocket clients.
+        /// WebSocketSharp invokes this on a background thread; we marshal the entire
+        /// message-handling body onto Unity's main thread via EditorApplication.delayCall
+        /// before touching any Editor APIs.
+        ///
+        /// Why this matters: accessing EditorStyles or scheduling EditorCoroutines from
+        /// a background thread can NRE inside PropertyEditor+Styles..cctor, which under
+        /// CLR rules permanently bricks that type for the rest of the AppDomain and
+        /// turns the Inspector black until Unity is restarted.
         /// </summary>
-        protected override async void OnMessage(MessageEventArgs e)
+        protected override void OnMessage(MessageEventArgs e)
+        {
+            string data = e.Data;
+            EditorApplication.delayCall += () => HandleMessageAsync(data);
+        }
+
+        /// <summary>
+        /// Process a WebSocket message on the Unity main thread.
+        /// Safe to call EditorCoroutineUtility, Selection, and other Editor APIs from here.
+        /// </summary>
+        private async void HandleMessageAsync(string data)
         {
             try
             {
-                McpLogger.LogInfo($"WebSocket message received: {e.Data}");
+                McpLogger.LogInfo($"WebSocket message received: {data}");
                 JObject requestJson;
                 try
                 {
-                    requestJson = JObject.Parse(e.Data);
+                    requestJson = JObject.Parse(data);
                 }
                 catch (JsonReaderException jre)
                 {
-                    McpLogger.LogError($"Invalid JSON received: {jre.Message}. Data: {e.Data}");
+                    McpLogger.LogError($"Invalid JSON received: {jre.Message}. Data: {data}");
                     // Attempt to send a parse error response. No requestId is available yet.
                     Send(CreateResponse(null, CreateErrorResponse($"Invalid JSON format: {jre.Message}", "invalid_json")).ToString(Formatting.None));
                     return;
@@ -76,7 +95,7 @@ namespace McpUnity.Unity
                 var requestId = requestJson["id"]?.ToString();
                 // We need to dispatch to Unity's main thread and wait for completion
                 var tcs = new TaskCompletionSource<JObject>();
-                
+
                 if (string.IsNullOrEmpty(method))
                 {
                     tcs.SetResult(CreateErrorResponse("Missing method in request", "invalid_request"));
@@ -93,20 +112,20 @@ namespace McpUnity.Unity
                 {
                     tcs.SetResult(CreateErrorResponse($"Unknown method: {method}", "unknown_method"));
                 }
-                
+
                 JObject responseJson = await tcs.Task;
                 JObject jsonRpcResponse = CreateResponse(requestId, responseJson);
                 string responseStr = jsonRpcResponse.ToString(Formatting.None);
-                
+
                 McpLogger.LogInfo($"WebSocket message response for request ID '{requestId}': {responseStr}");
-                
+
                 // Send the response back to the client
                 Send(responseStr);
             }
             catch (Exception ex)
             {
                 McpLogger.LogError($"Error processing message: {ex.Message}");
-                
+
                 Send(CreateErrorResponse($"Internal server error: {ex.Message}", "internal_error").ToString(Formatting.None));
             }
         }


### PR DESCRIPTION
Fixes #138.

## Problem

`McpUnitySocketHandler.OnMessage` is declared `async void` and runs on a WebSocketSharp thread-pool thread. Tool execution starts via `EditorCoroutineUtility.StartCoroutineOwnerless`, but `EditorCoroutine.MoveNext()` runs the first iteration synchronously on the caller's thread — so `tool.Execute(...)` and any Editor API it touches run on the WebSocket thread before the first `yield`.

When `SelectGameObjectTool` (lines 59, 62) or `AddAssetToSceneTool` (lines 122, 123) sets `Selection.activeGameObject` and calls `EditorGUIUtility.PingObject`, the Inspector tries to lazy-init `PropertyEditor+Styles` on that wrong thread. `EditorStyles.toolbarButtonRight` returns null, the cctor throws once, and under CLR rules the type stays permanently broken for the rest of the AppDomain. Inspector goes black, error spams on every `OnInspectorUpdate` tick, only fix is restarting Unity.

Full stack trace and root-cause analysis: #138.

## Fix

Marshal the entire `OnMessage` body onto the main thread via `EditorApplication.delayCall` before touching any Editor API. The handler now does just one thing on the WebSocket thread — captures `e.Data` into a local and queues the work — then a new `HandleMessageAsync(string data)` runs on the main thread with the original async/await + tcs flow intact.

Because the fix is at the dispatch boundary, every existing and future tool benefits, and no per-tool changes are needed.

## Diff summary

Single file: `Editor/UnityBridge/McpUnitySocketHandler.cs` (+29 / -10).

- Add `using UnityEditor;`.
- `OnMessage` becomes a plain `void` that does `EditorApplication.delayCall += () => HandleMessageAsync(e.Data);`.
- The previous body is moved verbatim into `private async void HandleMessageAsync(string data)`.
- No other behavior changes.

## Verification

Tested in a Unity 6 project against the patched `com.mcp.unity` package:

- Clean recompile, 0 errors (only the pre-existing obsolete-API warnings unrelated to this change).
- Stress test from an MCP client: parallel `select_gameobject` (3×) + `update_component` + `get_gameobject` + `get_scene_info`, repeated, with the Inspector pinned to a populated `GameObject` throughout.
- 0 console errors. Inspector stays rendered and responsive across the run.

## Notes

- `Send(responseStr)` invoked from the main thread is fine — WebSocketSharp handles cross-thread sends internally.
- `EditorApplication.delayCall` is a one-shot callback fired on the next editor tick on the main thread; queued calls are drained in order, so message ordering is preserved.
- If concurrent in-flight handlers are a concern (e.g., long-running async tool returns out of order), that's an orthogonal issue — this PR does not change the existing serialization characteristics, only the thread on which the dispatch occurs.