### PR TITLE
Fix: WebSocket server never restarts on EnteredPlayMode with domain reload disabled

### DIFF
--- a/Editor/UnityBridge/McpUnityServer.cs
+++ b/Editor/UnityBridge/McpUnityServer.cs
@@ -762,8 +762,24 @@ namespace McpUnity.Unity
                     }
                     break;
                 case PlayModeStateChange.EnteredPlayMode:
+                    // The assumption above (server stays down through Play, a domain reload on exit
+                    // will restart it) only holds when Enter Play Mode Options are OFF or don't disable
+                    // domain reload. With "Reload Scene without Reload Domain" -- Project Settings >
+                    // Editor > Enter Play Mode Options, a real, supported Unity profile some projects
+                    // pick specifically for iteration speed -- NO domain reload happens on either side
+                    // of Play Mode, so nothing was ever going to bring the server back. That leaves it
+                    // down for the entire Play session, with no way for a client to even ask Unity to
+                    // exit Play, since that request needs this same server. Confirmed live: a client
+                    // got locked in Play with no way out until the Editor was closed by hand.
+                    // Restarting here covers both profiles: if a domain reload already restarted it via
+                    // OnAfterAssemblyReload, IsListening is already true and this is a no-op; if it
+                    // didn't, this is the only thing that brings it back.
+                    if (!_instance.IsListening && McpUnitySettings.Instance.AutoStartServer)
+                    {
+                        _instance.ScheduleStartServer(requireAutoStart: true, reason: "entered play mode");
+                    }
+                    break;
                 case PlayModeStateChange.ExitingPlayMode:
-                    // Server is disabled during play mode as domain reload will be triggered again when stopped.
                     break;
                 case PlayModeStateChange.EnteredEditMode:
                     // Returned to Edit Mode


### PR DESCRIPTION
## Bug

`OnPlayModeStateChanged` in `McpUnityServer.cs` stops the server on `ExitingEditMode` and relies entirely on a domain reload (`OnAfterAssemblyReload`) to bring it back — it never restarts the server on `EnteredPlayMode` itself:

```csharp
case PlayModeStateChange.EnteredPlayMode:
case PlayModeStateChange.ExitingPlayMode:
    // Server is disabled during play mode as domain reload will be triggered again when stopped.
    break;
```

That assumption holds when Enter Play Mode Options are off (or don't disable domain reload). It breaks completely under **"Reload Scene without Reload Domain"** (Project Settings > Editor > Enter Play Mode Options → `EnterPlayModeOptions.DisableDomainReload`), a real, supported Unity profile a number of projects use specifically for faster iteration.

With that profile, no domain reload happens on either side of Play Mode — so nothing ever restarts the server. It stays down for the entire Play session, with no way for an MCP client to even ask Unity to exit Play, since that request needs this same server.

## Confirmed live

Reproduced directly: with domain reload disabled, entering Play mode via `execute_menu_item` stopped the server as expected, but it never came back. The client was locked in Play mode with no way out except closing the Editor by hand.

## Fix

Also attempt a restart on `EnteredPlayMode`, guarded by `!IsListening` so it's a no-op when a domain reload already handled it — the existing behavior for projects with domain reload enabled is unchanged. One small, self-contained change covers both Enter Play Mode Options profiles.

## Test plan

- [x] Reproduced the lockup with domain reload disabled before the fix
- [x] Confirmed the fix resolves it: server restarts on `EnteredPlayMode`, client reconnects without needing to exit Play first
- [x] Confirmed no regression with domain reload enabled (server still restarts via the existing `OnAfterAssemblyReload` path in that profile, this change is a no-op there since `IsListening` is already true by the time `EnteredPlayMode` fires)