### PR TITLE
fix(server): keep an error listener attached across terminate() so a connect timeout cannot kill the process

### DIFF
--- a/Server~/src/unity/unityConnection.ts
+++ b/Server~/src/unity/unityConnection.ts
@@ -487,9 +487,18 @@ export class UnityConnection extends EventEmitter {
     // Remove all event handlers before terminating
     socket.onopen = null;
     socket.onmessage = null;
-    socket.onerror = null;
     socket.onclose = null;
     socket.removeAllListeners('pong');
+
+    // Keep a no-op 'error' listener attached across terminate().
+    //
+    // ws@8 terminate() on a socket still in CONNECTING state calls abortHandshake(),
+    // which builds the Error synchronously but emits it on process.nextTick - i.e.
+    // OUTSIDE the try/catch below. With no 'error' listener the EventEmitter rethrows,
+    // index.ts's uncaughtException handler does not match EPIPE/EOF/ERR_USE_AFTER_CLOSE
+    // (the error has no .code at all), and the process exits 1 - killing the server on
+    // the very first connect timeout, before any reconnect attempt can run.
+    socket.onerror = () => { /* teardown is expected to fail; swallow */ };
 
     try {
       // Always terminate immediately — no graceful close handshake.


### PR DESCRIPTION
Fixes #153.

## Problem

`UnityConnection.closeWebSocket()` sets `socket.onerror = null` and then calls `socket.terminate()`.

When the socket is still `CONNECTING` — which is exactly the 5s connect-timeout path — ws@8's `terminate()` routes to `abortHandshake()`, which emits an `'error'` event. The Error is built **synchronously** (so its stack misleadingly points at `closeWebSocket`) but **emitted on `process.nextTick`**, i.e. outside the surrounding `try/catch`. With no `'error'` listener attached, the EventEmitter rethrows.

`index.ts`'s `uncaughtException` handler only tolerates `EPIPE` / `EOF` / `ERR_USE_AFTER_CLOSE`. This error carries **no `.code` at all**, so it falls through to `process.exit(1)`.

Net effect: the server process dies on the **first** connect timeout, before reconnect attempt 1 ever runs — and silently, since logging is off by default. It is most visible when Unity is mid-domain-reload (TCP is accepted but the WebSocket handshake never completes), which is precisely the situation the reconnect/backoff logic exists to carry you through.

## Fix

Leave a no-op `'error'` handler attached across `terminate()`, so `abortHandshake`'s emit has somewhere to land. This is the fix proposed by @LootGoblin in #153.

## Verification

Standalone reproduction (no Unity required), ws@8.18.1 / Node 24. A TCP listener accepts the connection but never speaks WebSocket, holding the client in `CONNECTING`; the exact `closeWebSocket` teardown sequence then runs.

| leg | result |
|---|---|
| current `main` behaviour | **exit 1** — `WebSocket was closed before the connection was established` (`code=undefined`) |
| with this patch | **exit 0** — survives; reconnect/backoff proceeds |

On this branch:

- `npm run build` — passes
- `npm test` — passes, 11 suites / 117 tests

This change has also been running in production in a fork for ~14 hours across ~10 domain reloads and several multi-minute Unity outages, with the proxy surviving every one.

## Scope

One line changed (`socket.onerror = null` replaced by a no-op handler) plus an explanatory comment.

No behavioural change on any path where the socket is already `OPEN`, since `terminate()` on an OPEN socket does not call `abortHandshake()`.

Happy to add a regression test to the Jest suite if you would like one — I kept this PR minimal deliberately.
