### PR TITLE
feat(server): detect a bound-but-unserviced port and report it (refs #141)

### DIFF
--- a/Editor/UnityBridge/McpUnityServer.cs
+++ b/Editor/UnityBridge/McpUnityServer.cs
@@ -42,6 +42,10 @@ namespace McpUnity.Unity
         private const int DelayedStartMaxAttempts = 10;
         private static readonly double[] DelayedStartRetryDelaySeconds = { 0.25d, 0.5d, 1d, 2d, 3d, 5d };
 
+        // Connect + read budget for the post-start liveness probe. Generous enough not to trip on a
+        // busy editor, short enough that the probe thread is always gone long before the next start.
+        private const int LivenessProbeTimeoutMs = 2000;
+
         private WebSocketServer _webSocketServer;
         private CancellationTokenSource _cts;
         private TestRunnerService _testRunnerService;
@@ -314,6 +318,11 @@ namespace McpUnity.Unity
                 _activeConnectionGeneration = connectionGeneration;
                 McpBackgroundTick.Start();
                 McpLogger.LogInfo($"WebSocket server started successfully on {host}:{McpUnitySettings.Instance.Port}.");
+
+                // Start() succeeding only proves the bind succeeded, not that the port is being
+                // serviced. Confirm the latter out-of-band (see the method's remarks).
+                VerifyServerIsActuallyServing(host, McpUnitySettings.Instance.Port);
+
                 return StartServerResult.Started;
             }
             catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressAlreadyInUse)
@@ -344,6 +353,124 @@ namespace McpUnity.Unity
             int normalizedAttempt = Math.Max(attempt, 1);
             int delayIndex = Math.Min(normalizedAttempt - 1, DelayedStartRetryDelaySeconds.Length - 1);
             return DelayedStartRetryDelaySeconds[delayIndex];
+        }
+
+        /// <summary>
+        /// Confirms out-of-band that the port just bound is actually being serviced.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A successful <c>WebSocketServer.Start()</c> proves only that the bind succeeded. On
+        /// Windows it is possible to end up bound to a port that then accepts TCP connections and
+        /// never answers them, so the editor reports a healthy server while every client hangs.
+        /// Reported as issue #141 ("Port N is already in use", cleared only by restarting Unity).
+        /// </para>
+        /// <para>
+        /// Silence with the connection held open is the distinguishing signature: a healthy server
+        /// either answers or closes the socket. So "data received" AND "peer closed" both count as
+        /// alive, and only a read timeout counts as dead.
+        /// </para>
+        /// <para>
+        /// This only DETECTS and reports the condition; it deliberately does not try to repair it.
+        /// The message therefore describes what was observed rather than asserting a cause.
+        /// </para>
+        /// <para>
+        /// Every resolved address must be tried. Binding "localhost" can yield an IPv6-only
+        /// listener (::1), against which 127.0.0.1 is refused - so a default <c>new TcpClient()</c>
+        /// (which is IPv4) cannot reach a perfectly healthy server and would false-alarm.
+        /// </para>
+        /// <para>
+        /// Runs off the main thread, and uses a deliberately non-existent path so it can never
+        /// create a /McpUnity session. Only LogWarning/LogError are called from the worker.
+        /// </para>
+        /// </remarks>
+        private static void VerifyServerIsActuallyServing(string host, int port)
+        {
+            var probeHost = host == "0.0.0.0" ? "localhost" : host;
+
+            var probe = new Thread(() =>
+            {
+                try
+                {
+                    // Let the accept loop settle; Start() can return marginally early.
+                    Thread.Sleep(250);
+
+                    System.Net.IPAddress[] addresses;
+                    try
+                    {
+                        addresses = System.Net.Dns.GetHostAddresses(probeHost);
+                    }
+                    catch
+                    {
+                        return;
+                    }
+
+                    foreach (var address in addresses)
+                    {
+                        using (var client = new TcpClient(address.AddressFamily))
+                        {
+                            try
+                            {
+                                if (!client.ConnectAsync(address, port).Wait(LivenessProbeTimeoutMs))
+                                {
+                                    continue;
+                                }
+                            }
+                            catch
+                            {
+                                // Refused/unreachable on this family - try the next address.
+                                continue;
+                            }
+
+                            var stream = client.GetStream();
+                            stream.ReadTimeout = LivenessProbeTimeoutMs;
+
+                            // A healthy websocket-sharp answers "HTTP/1.1 501 Not Implemented" to an
+                            // unknown path and closes, which proves the accept loop is live without
+                            // ever creating a /McpUnity session.
+                            var request = System.Text.Encoding.ASCII.GetBytes(
+                                "GET /__mcp_liveness__ HTTP/1.1\r\n" +
+                                $"Host: {probeHost}:{port}\r\n" +
+                                "Upgrade: websocket\r\n" +
+                                "Connection: Upgrade\r\n" +
+                                "Sec-WebSocket-Key: AAAAAAAAAAAAAAAAAAAAAA==\r\n" +
+                                "Sec-WebSocket-Version: 13\r\n\r\n");
+                            stream.Write(request, 0, request.Length);
+
+                            var buffer = new byte[64];
+                            try
+                            {
+                                // Returns >0 (answered) or 0 (peer closed) on a live server; throws
+                                // IOException on timeout only when nobody is servicing the port.
+                                stream.Read(buffer, 0, buffer.Length);
+                            }
+                            catch (IOException)
+                            {
+                                McpLogger.LogError(
+                                    $"MCP bridge is not serving: port {port} accepted a connection but " +
+                                    "returned nothing and did not close it. Clients will hang rather than " +
+                                    "fail. Restarting the server from the Server Window may not clear " +
+                                    "this; restarting the Unity Editor does.");
+                            }
+
+                            // One successful connect is a conclusive test either way.
+                            return;
+                        }
+                    }
+
+                    // No address accepted a connection at all. That is ambiguous - the listener may
+                    // still be settling - and the Node bridge's own connect is the authoritative
+                    // test, so stay silent rather than false-alarm.
+                }
+                catch (Exception ex)
+                {
+                    McpLogger.LogWarning($"MCP liveness probe failed to run: {ex.Message}");
+                }
+            });
+
+            probe.IsBackground = true;
+            probe.Name = "McpUnity Liveness Probe";
+            probe.Start();
         }
 
         private void ScheduleStartServer(bool requireAutoStart, string reason, int attempt = 1)

--- a/Editor/UnityBridge/McpUnityServer.cs
+++ b/Editor/UnityBridge/McpUnityServer.cs
@@ -58,6 +58,12 @@ namespace McpUnity.Unity
         private int _connectionGeneration;
         private int _activeConnectionGeneration;
 
+        // Cancelled by StopServer() so a liveness probe can never outlive the server generation
+        // it was started for. Deliberately never Disposed: the probe thread may still poll the
+        // token after replacement, a CTS without a timer holds no critical resources, and churn
+        // is bounded at one per server start.
+        private CancellationTokenSource _livenessProbeCancellation;
+
         private enum StartServerResult
         {
             Started,
@@ -164,6 +170,7 @@ namespace McpUnity.Unity
         {
             CancelScheduledStart();
             _activeConnectionGeneration = 0;
+            _livenessProbeCancellation?.Cancel();
             McpBackgroundTick.Stop();
 
             if (_webSocketServer == null)
@@ -320,8 +327,13 @@ namespace McpUnity.Unity
                 McpLogger.LogInfo($"WebSocket server started successfully on {host}:{McpUnitySettings.Instance.Port}.");
 
                 // Start() succeeding only proves the bind succeeded, not that the port is being
-                // serviced. Confirm the latter out-of-band (see the method's remarks).
-                VerifyServerIsActuallyServing(host, McpUnitySettings.Instance.Port);
+                // serviced. Confirm the latter out-of-band (see the method's remarks). The probe
+                // carries this start's generation and a token cancelled on StopServer(), so a
+                // probe from a replaced server can never report against its successor.
+                _livenessProbeCancellation?.Cancel();
+                _livenessProbeCancellation = new CancellationTokenSource();
+                VerifyServerIsActuallyServing(host, McpUnitySettings.Instance.Port,
+                    connectionGeneration, _livenessProbeCancellation.Token);
 
                 return StartServerResult.Started;
             }
@@ -368,7 +380,19 @@ namespace McpUnity.Unity
         /// <para>
         /// Silence with the connection held open is the distinguishing signature: a healthy server
         /// either answers or closes the socket. So "data received" AND "peer closed" both count as
-        /// alive, and only a read timeout counts as dead.
+        /// alive, and only a read TIMEOUT counts as dead - <see cref="IOException"/> alone does
+        /// not: <c>NetworkStream.Read</c> also raises it for connection resets and aborted
+        /// sockets (an ordinary shutdown/restart race), so the inner
+        /// <see cref="SocketException"/> is inspected and only <see cref="SocketError.TimedOut"/>
+        /// triggers the dead-server report. Other socket failures stay silent, matching the
+        /// no-connect case below: ambiguous evidence never raises the severe diagnostic.
+        /// </para>
+        /// <para>
+        /// The probe is tied to the server generation that launched it: it carries that
+        /// generation plus a token cancelled by <c>StopServer()</c>, and re-checks both before
+        /// every side effect - so a probe that slept or blocked in <c>Read</c> across a server
+        /// replacement exits silently instead of reporting a stale verdict against a healthy
+        /// successor.
         /// </para>
         /// <para>
         /// This only DETECTS and reports the condition; it deliberately does not try to repair it.
@@ -384,16 +408,28 @@ namespace McpUnity.Unity
         /// create a /McpUnity session. Only LogWarning/LogError are called from the worker.
         /// </para>
         /// </remarks>
-        private static void VerifyServerIsActuallyServing(string host, int port)
+        private void VerifyServerIsActuallyServing(string host, int port, int connectionGeneration,
+            CancellationToken cancellation)
         {
             var probeHost = host == "0.0.0.0" ? "localhost" : host;
+
+            // True while the server generation this probe was launched for is still the active
+            // one and no stop has been requested. Checked before every side effect: a stale
+            // probe must exit silently, never report against a replacement server.
+            bool ProbeIsCurrent() =>
+                !cancellation.IsCancellationRequested &&
+                Volatile.Read(ref _activeConnectionGeneration) == connectionGeneration;
 
             var probe = new Thread(() =>
             {
                 try
                 {
-                    // Let the accept loop settle; Start() can return marginally early.
-                    Thread.Sleep(250);
+                    // Let the accept loop settle; Start() can return marginally early. The wait
+                    // doubles as the cancellation point for a stop during the settle window.
+                    if (cancellation.WaitHandle.WaitOne(250))
+                    {
+                        return;
+                    }
 
                     System.Net.IPAddress[] addresses;
                     try
@@ -407,14 +443,23 @@ namespace McpUnity.Unity
 
                     foreach (var address in addresses)
                     {
+                        if (!ProbeIsCurrent())
+                        {
+                            return;
+                        }
+
                         using (var client = new TcpClient(address.AddressFamily))
                         {
                             try
                             {
-                                if (!client.ConnectAsync(address, port).Wait(LivenessProbeTimeoutMs))
+                                if (!client.ConnectAsync(address, port).Wait(LivenessProbeTimeoutMs, cancellation))
                                 {
                                     continue;
                                 }
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                return;
                             }
                             catch
                             {
@@ -440,17 +485,27 @@ namespace McpUnity.Unity
                             var buffer = new byte[64];
                             try
                             {
-                                // Returns >0 (answered) or 0 (peer closed) on a live server; throws
-                                // IOException on timeout only when nobody is servicing the port.
+                                // Returns >0 (answered) or 0 (peer closed) on a live server. A
+                                // throw is NOT proof of death by itself - see the catch below.
                                 stream.Read(buffer, 0, buffer.Length);
                             }
-                            catch (IOException)
+                            catch (IOException ex)
                             {
-                                McpLogger.LogError(
-                                    $"MCP bridge is not serving: port {port} accepted a connection but " +
-                                    "returned nothing and did not close it. Clients will hang rather than " +
-                                    "fail. Restarting the server from the Server Window may not clear " +
-                                    "this; restarting the Unity Editor does.");
+                                // Read() raises IOException for more than the timeout: connection
+                                // resets and aborted sockets surface here too, and those are the
+                                // signature of an ordinary shutdown/restart race, not of the
+                                // silent port (which holds the connection OPEN in silence). Only
+                                // the timeout code is the dead-server signal; everything else
+                                // stays silent, like the no-connect case below.
+                                var socketError = (ex.InnerException as SocketException)?.SocketErrorCode;
+                                if (socketError == SocketError.TimedOut && ProbeIsCurrent())
+                                {
+                                    McpLogger.LogError(
+                                        $"MCP bridge is not serving: port {port} accepted a connection but " +
+                                        "returned nothing and did not close it. Clients will hang rather than " +
+                                        "fail. Restarting the server from the Server Window may not clear " +
+                                        "this; restarting the Unity Editor does.");
+                                }
                             }
 
                             // One successful connect is a conclusive test either way.
@@ -464,7 +519,10 @@ namespace McpUnity.Unity
                 }
                 catch (Exception ex)
                 {
-                    McpLogger.LogWarning($"MCP liveness probe failed to run: {ex.Message}");
+                    if (ProbeIsCurrent())
+                    {
+                        McpLogger.LogWarning($"MCP liveness probe failed to run: {ex.Message}");
+                    }
                 }
             });
 


### PR DESCRIPTION
### Problem

`WebSocketServer.Start()` succeeding proves only that the **bind** succeeded — not that the port is
actually being serviced. On Windows the server can end up bound to a port that accepts TCP
connections and then never answers them. The editor logs `WebSocket server started successfully` and
looks healthy, while every client just hangs.

That matches the symptom reported in #141 (`Port <N> is already in use`, cleared only by restarting
Unity). I'd treat this as **related rather than identical** until someone confirms socket state on
that setup — #141 reports it on roughly half of recompiles, which is far more frequent than what
I've seen, so it may be a different trigger sharing a symptom.

On my side the port turned out to be held by **accepted sockets sitting in `CLOSE_WAIT`**, not by
the listener — which is why stopping/restarting the server from the Server Window doesn't clear it
(those sockets aren't reachable from managed code; no `WebSocketBehavior` exists for them). If
anyone hitting #141 can post raw `netstat -ano | findstr :<port>` output it'd be worth comparing —
raw `netstat`, not `Get-NetTCPConnection`, which collapses duplicate rows.

### What this does

Adds a short background probe after a successful start. It connects and sends a request for a
deliberately non-existent path (`/__mcp_liveness__`): a healthy websocket-sharp answers
`501 Not Implemented` and closes, which proves the accept loop is live **without ever creating a
`/McpUnity` session** or touching `Clients`.

Only a **read timeout** is treated as dead. Both "data received" and "peer closed" count as alive,
because silence *with the connection held open* is the distinguishing signature — a healthy server
either answers or closes.

Two things worth calling out:

- **It tries every resolved address.** Binding `localhost` can yield an **IPv6-only** listener
  (`::1`), against which `127.0.0.1` is refused — so a default `new TcpClient()` (IPv4) cannot reach
  a perfectly healthy server. An earlier version of this probe did exactly that and false-alarmed on
  a working bridge.
- **It only detects and reports.** It deliberately doesn't attempt a repair, and the log message
  describes what was *observed* rather than asserting a cause. If no address accepts a connection at
  all it stays silent, since that's ambiguous (the listener may still be settling) and the Node
  bridge's own connect is the authoritative test.

Runs off the main thread, background thread, ~2 s budget, and only `LogWarning`/`LogError` are
called from the worker.

### Testing

- Compiles clean against `main` on **Unity 6000.4.6f1** (Windows), as an embedded package.
- Verified the compile check itself can fail: a deliberate syntax-error control leg produced 6
  `CS####` errors at the expected line, and the clean leg produced 0, with no
  `Multiple embedded packages found` warning in either — i.e. Unity really did compile *this* copy.
- Running against a healthy server: probe stays silent (no false positive).

### Notes

Single file, pure insertion (+127), no behaviour change on the healthy path beyond one short-lived
background thread per successful start. Happy to gate it behind a setting, cut the log to a warning,
or drop the message wording to something you prefer.
