### PR TITLE
fix(dashboard): start auto-refresh interval on load

### DIFF
--- a/Server~/src/ui/unity-dashboard.html
+++ b/Server~/src/ui/unity-dashboard.html
@@ -1550,6 +1550,10 @@
       }
       autoRefresh.onchange = scheduleAuto;
       interval.onchange = scheduleAuto;
+      // Start the interval for the initial checkbox state; without this the
+      // checked "Auto" box is inert until toggled and the dashboard only
+      // fetches once per page load.
+      scheduleAuto();
       focusFilter.onchange = () => {
         state.focusFilterEnabled = focusFilter.checked;
         renderHierarchy(state.lastHierarchy || []);


### PR DESCRIPTION
The dashboard's Auto checkbox renders checked by default, but `scheduleAuto()` is only wired to the checkbox and interval-slider `onchange` handlers — it is never invoked at startup. As a result the refresh interval never starts: `fetchAll()` runs exactly once per page load, and the dashboard silently stops tracking editor state (play mode, hierarchy, console) until the user toggles the checkbox or presses Refresh manually.

One-line fix: call `scheduleAuto()` once after wiring the handlers, so the interval honors the initial checkbox state.

Verified by watching the dashboard poll on its 3s cadence after load and follow play/stop and hierarchy changes without manual refreshes. `npm test`: 123/123 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)