### PR TITLE
feat: implement unity://inspector_state resource

### DIFF
--- a/Editor/Resources/GetInspectorStateResource.cs
+++ b/Editor/Resources/GetInspectorStateResource.cs
@@ -1,0 +1,98 @@
+using UnityEngine;
+using UnityEditor;
+using Newtonsoft.Json.Linq;
+using McpUnity.Utils;
+
+namespace McpUnity.Resources
+{
+    /// <summary>
+    /// Resource for retrieving the Unity Editor's current inspector focus:
+    /// the selected GameObject and, when determinable, the component the
+    /// user is looking at. Provides the unity://inspector_state resource
+    /// the Unity Dashboard app polls for its inspector-focus highlight.
+    /// </summary>
+    public class GetInspectorStateResource : McpResourceBase
+    {
+        public GetInspectorStateResource()
+        {
+            Name = "get_inspector_state";
+            Description = "Current Editor selection and inspected component (Unity Dashboard inspector focus)";
+            Uri = "unity://inspector_state";
+        }
+
+        /// <summary>
+        /// Fetch the current selection state from the Unity Editor
+        /// </summary>
+        /// <param name="parameters">Resource parameters as a JObject (not used)</param>
+        /// <returns>A JObject with activeGameObject {instanceId, name, path} and focusedComponent</returns>
+        public override JObject Fetch(JObject parameters)
+        {
+            GameObject selected = Selection.activeGameObject;
+            if (selected == null)
+            {
+                return new JObject
+                {
+                    ["success"] = true,
+                    ["message"] = "No GameObject selected",
+                    ["activeGameObject"] = null,
+                    ["focusedComponent"] = null
+                };
+            }
+
+            return new JObject
+            {
+                ["success"] = true,
+                ["message"] = $"Selected GameObject: '{selected.name}'",
+                ["activeGameObject"] = new JObject
+                {
+                    ["instanceId"] = UnityObjectId.GetObjectId(selected),
+                    ["name"] = selected.name,
+                    ["path"] = GetHierarchyPath(selected.transform)
+                },
+                ["focusedComponent"] = GetFocusedComponentName()
+            };
+        }
+
+        private static string GetHierarchyPath(Transform transform)
+        {
+            string path = transform.name;
+            while (transform.parent != null)
+            {
+                transform = transform.parent;
+                path = transform.name + "/" + path;
+            }
+            return path;
+        }
+
+        /// <summary>
+        /// Best-effort "component the user is looking at": the first expanded
+        /// non-Transform component editor in the active inspector. Unity has no
+        /// true focused-component API, so null is a legitimate answer.
+        /// </summary>
+        private static string GetFocusedComponentName()
+        {
+            ActiveEditorTracker tracker = ActiveEditorTracker.sharedTracker;
+            if (tracker == null)
+            {
+                return null;
+            }
+
+            UnityEditor.Editor[] editors = tracker.activeEditors;
+            for (int i = 0; i < editors.Length; i++)
+            {
+                UnityEditor.Editor editor = editors[i];
+                if (editor == null || editor.target == null || !(editor.target is Component component) || component is Transform)
+                {
+                    continue;
+                }
+
+                if (tracker.GetVisible(i) == 1)
+                {
+                    return component.GetType().Name;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Editor/Resources/GetInspectorStateResource.cs.meta
+++ b/Editor/Resources/GetInspectorStateResource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1e06396f8e16f471bb75be1f0d87867d

--- a/Editor/UnityBridge/McpUnityServer.cs
+++ b/Editor/UnityBridge/McpUnityServer.cs
@@ -918,6 +918,10 @@ namespace McpUnity.Unity
             // Register GetGameObjectResource
             GetGameObjectResource getGameObjectResource = new GetGameObjectResource();
             _resources.Add(getGameObjectResource.Name, getGameObjectResource);
+
+            // Register GetInspectorStateResource
+            GetInspectorStateResource getInspectorStateResource = new GetInspectorStateResource();
+            _resources.Add(getInspectorStateResource.Name, getInspectorStateResource);
         }
         
         /// <summary>

--- a/Server~/src/index.ts
+++ b/Server~/src/index.ts
@@ -36,6 +36,7 @@ import { registerGetPackagesResource } from './resources/getPackagesResource.js'
 import { registerGetAssetsResource } from './resources/getAssetsResource.js';
 import { registerGetTestsResource } from './resources/getTestsResource.js';
 import { registerGetGameObjectResource } from './resources/getGameObjectResource.js';
+import { registerGetInspectorStateResource } from './resources/getInspectorStateResource.js';
 import { registerUnityDashboardAppResource } from './resources/unityDashboardAppResource.js';
 import { registerGameObjectHandlingPrompt } from './prompts/gameobjectHandlingPrompt.js';
 import { registerUnityDashboardPrompt } from './prompts/unityDashboardPrompt.js';
@@ -109,6 +110,7 @@ registerGetConsoleLogsResource(server, mcpUnity, resourceLogger);
 registerGetHierarchyResource(server, mcpUnity, resourceLogger);
 registerGetPackagesResource(server, mcpUnity, resourceLogger);
 registerGetAssetsResource(server, mcpUnity, resourceLogger);
+registerGetInspectorStateResource(server, mcpUnity, resourceLogger);
 registerUnityDashboardAppResource(server, resourceLogger);
 
 // Register all prompts into the MCP server

--- a/Server~/src/resources/getInspectorStateResource.ts
+++ b/Server~/src/resources/getInspectorStateResource.ts
@@ -1,0 +1,72 @@
+import { McpUnity } from '../unity/mcpUnity.js';
+import { Logger } from '../utils/logger.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpUnityError, ErrorType } from '../utils/errors.js';
+import { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+
+// Constants for the resource
+const resourceName = 'get_inspector_state';
+const resourceUri = 'unity://inspector_state';
+const resourceMimeType = 'application/json';
+
+/**
+ * Creates and registers the Inspector State resource with the MCP server.
+ * Provides the Editor's current selection and inspected component; the
+ * Unity Dashboard app polls this URI for its inspector-focus highlight.
+ *
+ * @param server The MCP server instance to register with
+ * @param mcpUnity The McpUnity instance to communicate with Unity
+ * @param logger The logger instance for diagnostic information
+ */
+export function registerGetInspectorStateResource(server: McpServer, mcpUnity: McpUnity, logger: Logger) {
+  logger.info(`Registering resource: ${resourceName}`);
+
+  server.resource(
+    resourceName,
+    resourceUri,
+    {
+      description: "Current Editor selection and inspected component (Unity Dashboard inspector focus)",
+      mimeType: resourceMimeType
+    },
+    async () => {
+      try {
+        return await resourceHandler(mcpUnity);
+      } catch (error) {
+        logger.error(`Error handling resource ${resourceName}: ${error}`);
+        throw error;
+      }
+    }
+  );
+}
+
+/**
+ * Handles requests for the Editor's inspector state from Unity
+ *
+ * @param mcpUnity The McpUnity instance to communicate with Unity
+ * @returns A promise that resolves to the inspector state payload
+ * @throws McpUnityError if the request to Unity fails
+ */
+async function resourceHandler(mcpUnity: McpUnity): Promise<ReadResourceResult> {
+  const response = await mcpUnity.sendRequest({
+    method: resourceName,
+    params: {}
+  });
+
+  if (!response.success) {
+    throw new McpUnityError(
+      ErrorType.RESOURCE_FETCH,
+      response.message || 'Failed to fetch inspector state from Unity'
+    );
+  }
+
+  return {
+    contents: [{
+      uri: resourceUri,
+      mimeType: resourceMimeType,
+      text: JSON.stringify({
+        activeGameObject: response.activeGameObject ?? null,
+        focusedComponent: response.focusedComponent ?? null
+      }, null, 2)
+    }]
+  };
+}


### PR DESCRIPTION
The Unity Dashboard app polls `unity://inspector_state` for its inspector-focus feature (`readResourceJson('unity://inspector_state')` in `unity-dashboard.html`), but no provider exists on either the Unity or the Node side — the read always fails, and the hierarchy never highlights the GameObject selected in the editor.

This adds the provider end to end:

- **`Editor/Resources/GetInspectorStateResource.cs`** reports `Selection.activeGameObject` as `{instanceId (via UnityObjectId), name, path}` plus a best-effort `focusedComponent` from the first expanded non-Transform editor in `ActiveEditorTracker` (Unity has no true focused-component API, so `null` is a legitimate answer). Registered in `McpUnityServer.RegisterResources()`.
- **`Server~/src/resources/getInspectorStateResource.ts`** registers `get_inspector_state` / `unity://inspector_state` and unwraps the Unity response into the `{activeGameObject, focusedComponent}` payload the dashboard parses.

With this in place, the dashboard hierarchy highlights the editor's selection and follows it as it changes (verified live against Unity 6000.4). `npm test`: 123/123 pass. Note: full effect also needs the auto-refresh fix in the companion PR #160, since without it the dashboard only polls once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)